### PR TITLE
Rework modules getInstance functionality

### DIFF
--- a/src/js/components/ModuleController.ts
+++ b/src/js/components/ModuleController.ts
@@ -1,0 +1,52 @@
+import { RE6Module } from "./RE6Module";
+
+export class ModuleController {
+
+    private static modules: Map<string, RE6Module> = new Map();
+
+    /**
+     * Registers the module so that its settings could be changed
+     * @param module Module to register
+     * @todo any parameter is not correct here but I couldn't figure the right types out
+     *  { new(): RE6Module } works to access constructor name but not static methods
+     */
+    public static register(moduleClass: any): void {
+        const moduleInstance = moduleClass.getInstance();
+        moduleInstance.create();
+        this.modules.set(moduleClass.prototype.constructor.name, moduleInstance);
+    }
+
+    /**
+     * Returns a previously registered module with the specified class
+     * This simply calls the non static variant, making the use in this class a bit more convinien
+     * @param moduleClass Module class
+     * @returns the module interpreted as T (which must extend the RE6Module class)
+     */
+    public static getWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
+        return this.getByName(moduleClass.prototype.constructor.name) as T;
+    }
+
+    /**
+     * Same as getModuleWithType except that it returns it as a RE6Module
+     * This simply calls the non static variant, making the use in this class a bit more convinien
+     * @param moduleClass 
+     * @returns RE6Module instance
+     */
+    public static get(moduleClass: { new(): RE6Module }): RE6Module {
+        return this.getByName(moduleClass.prototype.constructor.name);
+    }
+
+    /**
+     * Gets a module without a specific tpye from the passed class name
+     */
+    public static getByName(name: string): RE6Module {
+        return this.modules.get(name);
+    }
+
+    /**
+     * @returns a map of all registered modules
+     */
+    public static getAll() {
+        return this.modules;
+    }
+}

--- a/src/js/components/ModuleController.ts
+++ b/src/js/components/ModuleController.ts
@@ -46,7 +46,7 @@ export class ModuleController {
     /**
      * @returns a map of all registered modules
      */
-    public static getAll() {
+    public static getAll(): Map<string, RE6Module> {
         return this.modules;
     }
 }

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -170,9 +170,9 @@ export class RE6Module {
     }
 
     /**
- * Returns a singleton instance of the class
- * @returns FormattingHelper instance
- */
+     * Returns a singleton instance of the class
+     * @returns FormattingHelper instance
+     */
     public static getInstance(): RE6Module {
         if (this.instance == undefined) this.instance = new this();
         return this.instance;

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -173,7 +173,7 @@ export class RE6Module {
      * Returns a singleton instance of the class
      * @returns FormattingHelper instance
      */
-    public static getInstance(): RE6Module {
+    protected static getInstance(): RE6Module {
         if (this.instance == undefined) this.instance = new this();
         return this.instance;
     }

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -93,6 +93,9 @@ export class RE6Module {
     public fetchSettings(property?: string, fresh?: boolean): any {
         if (fresh) this.loadSettingsData();
         if (property === undefined) return this.settings;
+        if (this.settings[property] === undefined) {
+            debugger;
+        }
         return this.settings[property];
     }
 

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -5,10 +5,12 @@ declare const GM_getValue;
 declare const GM_setValue;
 
 /**
- * Abstract class that other modules extend.  
+ * Class that other modules extend.  
  * Provides methods to save and load settings from cookies.
  */
 export class RE6Module {
+
+    private static instance: RE6Module;
 
     private settings: Settings;
     private readonly prefix: string = this.constructor.name;
@@ -165,6 +167,15 @@ export class RE6Module {
     protected registerHotkeys(...hotkeys: Hotkey[]): void {
         this.hotkeys = this.hotkeys.concat(hotkeys);
         this.resetHotkeys();
+    }
+
+    /**
+ * Returns a singleton instance of the class
+ * @returns FormattingHelper instance
+ */
+    public static getInstance(): RE6Module {
+        if (this.instance == undefined) this.instance = new this();
+        return this.instance;
     }
 
 }

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -21,7 +21,7 @@ export class RE6Module {
     private constraint: RegExp[] = [];
     private hotkeys: Hotkey[] = [];
 
-    protected constructor(constraint?: RegExp | RegExp[]) {
+    public constructor(constraint?: RegExp | RegExp[]) {
         if (constraint === undefined) this.constraint = [];
         else if (constraint instanceof RegExp) this.constraint.push(constraint);
         else this.constraint = constraint;

--- a/src/js/components/RE6Module.ts
+++ b/src/js/components/RE6Module.ts
@@ -93,9 +93,6 @@ export class RE6Module {
     public fetchSettings(property?: string, fresh?: boolean): any {
         if (fresh) this.loadSettingsData();
         if (property === undefined) return this.settings;
-        if (this.settings[property] === undefined) {
-            debugger;
-        }
         return this.settings[property];
     }
 

--- a/src/js/components/data/User.ts
+++ b/src/js/components/data/User.ts
@@ -10,8 +10,6 @@ import { ApiUserSettings } from "../api/responses/ApiUserSettings";
  */
 export class User extends RE6Module {
 
-    private static instance: User;
-
     private loggedin: boolean;
     private username: string;
     private userid: number;
@@ -20,7 +18,7 @@ export class User extends RE6Module {
 
     private blacklist = new Map<string, PostFilter>();
 
-    private constructor() {
+    public constructor() {
         super();
         const $ref = $("body");
 
@@ -37,13 +35,8 @@ export class User extends RE6Module {
         }
     }
 
-    /**
-     * Returns a singleton instance of the class
-     * @returns User instance
-     */
-    public static getInstance(): User {
-        if (this.instance === undefined) this.instance = new User();
-        return this.instance;
+    private static get(): User {
+        return super.getInstance() as User;
     }
 
     /**
@@ -51,7 +44,7 @@ export class User extends RE6Module {
      * @returns boolean true if the user is logged in, false otherwise
      */
     public static isLoggedIn(): boolean {
-        return this.getInstance().loggedin;
+        return this.get().loggedin;
     }
 
     /**
@@ -59,7 +52,7 @@ export class User extends RE6Module {
      * @returns string Username if the user is logged in, "Anonymous" otherwise
      */
     public static getUsername(): string {
-        return this.getInstance().username;
+        return this.get().username;
     }
 
     /**
@@ -67,7 +60,7 @@ export class User extends RE6Module {
      * @returns string User ID if the user is logged in, 0 otherwise
      */
     public static getUserID(): number {
-        return this.getInstance().userid;
+        return this.get().userid;
     }
 
     /**
@@ -75,7 +68,7 @@ export class User extends RE6Module {
      * @returns string Group if the user is logged in, "Guest" otherwise
      */
     public static getLevel(): string {
-        return this.getInstance().level;
+        return this.get().level;
     }
 
     /**
@@ -83,7 +76,7 @@ export class User extends RE6Module {
      * @returns PostFilter[] A array of the users current filters
      */
     public static getBlacklist(): Map<string, PostFilter> {
-        return this.getInstance().blacklist;
+        return this.get().blacklist;
     }
 
     /**

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -36,8 +36,8 @@ import { RE6Module } from "./components/RE6Module";
 
 const loadOrder = [
     { class: FormattingManager },
-    { class: ThemeCustomizer },
     { class: HeaderCustomizer },
+    { class: ThemeCustomizer },
     { class: Miscellaneous },
     { class: SubscriptionManager },
     { class: ThemeCustomizer },

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -32,37 +32,36 @@ import { TagSubscriptions } from "./modules/subscriptions/TagSubscriptions";
 // - settings
 import { SettingsController } from "./modules/general/SettingsController";
 import { Subscription } from "./modules/subscriptions/Subscription";
-import { RE6Module } from "./components/RE6Module";
 
 const loadOrder = [
-    { class: FormattingManager },
-    { class: HeaderCustomizer },
-    { class: ThemeCustomizer },
-    { class: Miscellaneous },
-    { class: SubscriptionManager },
-    { class: ThemeCustomizer },
+    FormattingManager,
+    HeaderCustomizer,
+    ThemeCustomizer,
+    Miscellaneous,
+    SubscriptionManager,
+    ThemeCustomizer,
 
-    { class: DownloadCustomizer },
-    { class: ImageScaler },
-    { class: PoolNavigator },
-    { class: PostViewer },
-    { class: TitleCustomizer },
+    DownloadCustomizer,
+    ImageScaler,
+    PoolNavigator,
+    PostViewer,
+    TitleCustomizer,
 
-    { class: BlacklistEnhancer },
-    { class: InfiniteScroll },
-    { class: InstantSearch },
+    BlacklistEnhancer,
+    InfiniteScroll,
+    InstantSearch,
 
-    { class: TinyAlias },
+    TinyAlias
 ];
 
 const subscriptions = [
-    { class: PoolSubscriptions },
-    { class: ForumSubscriptions },
-    { class: TagSubscriptions }
+    PoolSubscriptions,
+    ForumSubscriptions,
+    TagSubscriptions
 ];
 
 subscriptions.forEach((module) => {
-    const instance = module.class.getInstance() as Subscription;
+    const instance = module.getInstance() as Subscription;
     if (instance.canInitialize()) {
         SubscriptionManager.registerSubscriber(instance);
     }
@@ -71,7 +70,7 @@ subscriptions.forEach((module) => {
 StructureUtilities.createDOM();
 
 loadOrder.forEach((module) => {
-    SettingsController.registerModule(module.class);
+    SettingsController.registerModule(module);
 });
 
 SettingsController.getInstance().init();

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -31,6 +31,8 @@ import { PoolSubscriptions } from "./modules/subscriptions/PoolSubscriptions";
 import { TagSubscriptions } from "./modules/subscriptions/TagSubscriptions";
 // - settings
 import { SettingsController } from "./modules/general/SettingsController";
+import { Subscription } from "./modules/subscriptions/Subscription";
+import { RE6Module } from "./components/RE6Module";
 
 const loadOrder = [
     { class: FormattingManager },
@@ -53,25 +55,23 @@ const loadOrder = [
     { class: TinyAlias },
 ];
 
-const subscriptions = [
-    { class: PoolSubscriptions },
-    { class: ForumSubscriptions },
-    { class: TagSubscriptions }
-];
+// const subscriptions = [
+//     { class: PoolSubscriptions },
+//     { class: ForumSubscriptions },
+//     { class: TagSubscriptions }
+// ];
 
-subscriptions.forEach((module) => {
-    const instance = module.class.getInstance();
-    if (instance.canInitialize()) {
-        SubscriptionManager.registerSubscriber(instance);
-    }
-});
+// subscriptions.forEach((module) => {
+//     const instance = module.class.getInstance() as Subscription;
+//     if (instance.canInitialize()) {
+//         SubscriptionManager.registerSubscriber(instance);
+//     }
+// });
 
 StructureUtilities.createDOM();
 
 loadOrder.forEach((module) => {
-    const instance = module.class.getInstance();
-    if (instance.canInitialize()) instance.create();
-    SettingsController.registerModule(instance);
+    SettingsController.registerModule<RE6Module>(module.class);
 });
 
 SettingsController.getInstance().init();

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -71,7 +71,7 @@ subscriptions.forEach((module) => {
 StructureUtilities.createDOM();
 
 loadOrder.forEach((module) => {
-    SettingsController.registerModule<RE6Module>(module.class);
+    SettingsController.registerModule(module.class);
 });
 
 SettingsController.getInstance().init();

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -32,14 +32,13 @@ import { PoolSubscriptions } from "./modules/subscriptions/PoolSubscriptions";
 import { TagSubscriptions } from "./modules/subscriptions/TagSubscriptions";
 // - settings
 import { SettingsController } from "./modules/general/SettingsController";
-import { Subscription } from "./modules/subscriptions/Subscription";
+
 
 const loadOrder = [
     FormattingManager,
     HeaderCustomizer,
     ThemeCustomizer,
     Miscellaneous,
-    SubscriptionManager,
     ThemeCustomizer,
 
     DownloadCustomizer,
@@ -53,7 +52,7 @@ const loadOrder = [
     InstantSearch,
 
     TinyAlias,
-
+    SubscriptionManager,
     SettingsController
 ];
 
@@ -63,15 +62,13 @@ const subscriptions = [
     TagSubscriptions
 ];
 
-subscriptions.forEach((module) => {
-    const instance = module.getInstance() as Subscription;
-    if (instance.canInitialize()) {
-        SubscriptionManager.registerSubscriber(instance);
-    }
-});
-
 StructureUtilities.createDOM();
 
-loadOrder.forEach((module) => {
+subscriptions.forEach(module => {
+    ModuleController.register(module);
+    SubscriptionManager.register(module)
+});
+
+loadOrder.forEach(module => {
     ModuleController.register(module);
 });

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -6,6 +6,7 @@
 // Load Modules
 // - requied
 import { StructureUtilities } from "./modules/general/StructureUtilities";
+import { ModuleController } from "./components/ModuleController";
 // - general
 import { FormattingManager } from "./modules/general/FormattingHelper";
 import { HeaderCustomizer } from "./modules/general/HeaderCustomizer";
@@ -51,7 +52,9 @@ const loadOrder = [
     InfiniteScroll,
     InstantSearch,
 
-    TinyAlias
+    TinyAlias,
+
+    SettingsController
 ];
 
 const subscriptions = [
@@ -70,7 +73,5 @@ subscriptions.forEach((module) => {
 StructureUtilities.createDOM();
 
 loadOrder.forEach((module) => {
-    SettingsController.registerModule(module);
+    ModuleController.register(module);
 });
-
-SettingsController.getInstance().init();

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -55,18 +55,18 @@ const loadOrder = [
     { class: TinyAlias },
 ];
 
-// const subscriptions = [
-//     { class: PoolSubscriptions },
-//     { class: ForumSubscriptions },
-//     { class: TagSubscriptions }
-// ];
+const subscriptions = [
+    { class: PoolSubscriptions },
+    { class: ForumSubscriptions },
+    { class: TagSubscriptions }
+];
 
-// subscriptions.forEach((module) => {
-//     const instance = module.class.getInstance() as Subscription;
-//     if (instance.canInitialize()) {
-//         SubscriptionManager.registerSubscriber(instance);
-//     }
-// });
+subscriptions.forEach((module) => {
+    const instance = module.class.getInstance() as Subscription;
+    if (instance.canInitialize()) {
+        SubscriptionManager.registerSubscriber(instance);
+    }
+});
 
 StructureUtilities.createDOM();
 

--- a/src/js/modules/general/FormattingHelper.ts
+++ b/src/js/modules/general/FormattingHelper.ts
@@ -47,21 +47,10 @@ const iconDefinitions = [
 
 export class FormattingManager extends RE6Module {
 
-    private static instance: FormattingManager;
-
     private formatters: FormattingHelper[] = [];
 
-    private constructor() {
+    public constructor() {
         super();
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns FormattingHelper instance
-     */
-    public static getInstance(): FormattingManager {
-        if (this.instance == undefined) this.instance = new FormattingManager();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/general/FormattingHelper.ts
+++ b/src/js/modules/general/FormattingHelper.ts
@@ -4,6 +4,7 @@ import { Modal } from "../../components/structure/Modal";
 import { Form } from "../../components/structure/Form";
 import { Hotkeys } from "../../components/data/Hotkeys";
 import { Api } from "../../components/api/Api";
+import { ModuleController } from "../../components/ModuleController";
 
 // Avaliable icons for formatting buttons
 const iconDefinitions = [
@@ -143,7 +144,7 @@ class FormattingHelper {
 
     /** Registers the module's hotkeys */
     public registerHotkeys(): void {
-        const manager = FormattingManager.getInstance();
+        const manager = ModuleController.get(FormattingManager);
         Hotkeys.registerInput(manager.fetchSettings("hotkeySubmit"), this.$textarea, () => {
             if (!manager.fetchSettings("hotkeySubmitActive")) return;
             this.$form.submit();
@@ -370,7 +371,7 @@ class FormattingHelper {
     public loadButtons(): void {
         this.$formatButtons.empty();
 
-        FormattingManager.getInstance().fetchSettings("buttonsActive", true).forEach((data: ButtonDefinition) => {
+        ModuleController.get(FormattingManager).fetchSettings("buttonsActive", true).forEach((data: ButtonDefinition) => {
             const buttonElement = this.createButton(data);
             buttonElement.box.appendTo(this.$formatButtons);
 
@@ -381,7 +382,7 @@ class FormattingHelper {
         });
 
         this.$formatButtonsDrawer.empty();
-        FormattingManager.getInstance().fetchSettings("buttonInactive", true).forEach((data: ButtonDefinition) => {
+        ModuleController.get(FormattingManager).fetchSettings("buttonInactive", true).forEach((data: ButtonDefinition) => {
             const buttonData = this.createButton(data);
             buttonData.box.appendTo(this.$formatButtonsDrawer);
         });
@@ -393,13 +394,13 @@ class FormattingHelper {
         this.$formatButtons.find("li").each(function (i, element) {
             buttonData.push(fetchData(element));
         });
-        FormattingManager.getInstance().pushSettings("buttonsActive", buttonData);
+        ModuleController.get(FormattingManager).pushSettings("buttonsActive", buttonData);
 
         buttonData = [];
         this.$formatButtonsDrawer.find("li").each(function (i, element) {
             buttonData.push(fetchData(element));
         });
-        FormattingManager.getInstance().pushSettings("buttonInactive", buttonData);
+        ModuleController.get(FormattingManager).pushSettings("buttonInactive", buttonData);
 
         this.$container.trigger("re621:formatter:update", [this]);
 

--- a/src/js/modules/general/FormattingHelper.ts
+++ b/src/js/modules/general/FormattingHelper.ts
@@ -49,10 +49,6 @@ export class FormattingManager extends RE6Module {
 
     private formatters: FormattingHelper[] = [];
 
-    public constructor() {
-        super();
-    }
-
     /**
      * Returns a set of default settings values
      * @returns Default settings

--- a/src/js/modules/general/HeaderCustomizer.ts
+++ b/src/js/modules/general/HeaderCustomizer.ts
@@ -3,14 +3,13 @@ import { RE6Module, Settings } from "../../components/RE6Module";
 import { User } from "../../components/data/User";
 import { Form } from "../../components/structure/Form";
 import { Page } from "../../components/data/Page";
+import { SettingsController } from "./SettingsController";
 
 /**
  * HeaderCustomizer  
  * Add, remove, and re-arrange the tabs in the customizable navbar
  */
 export class HeaderCustomizer extends RE6Module {
-
-    private static instance: HeaderCustomizer;
 
     private $oldMenu: JQuery<HTMLElement>;
     private $menu: JQuery<HTMLElement>;
@@ -22,7 +21,7 @@ export class HeaderCustomizer extends RE6Module {
     private addTabModal: Modal;
     private addTabForm: Form;
 
-    private constructor() {
+    public constructor() {
         super();
         this.registerHotkeys(
             { keys: "hotkeyTab1", fnct: this.openTabNum },
@@ -35,15 +34,6 @@ export class HeaderCustomizer extends RE6Module {
             { keys: "hotkeyTab8", fnct: this.openTabNum },
             { keys: "hotkeyTab9", fnct: this.openTabNum },
         );
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns HeaderCustomizer instance
-     */
-    public static getInstance(): HeaderCustomizer {
-        if (this.instance == undefined) this.instance = new HeaderCustomizer();
-        return this.instance;
     }
 
     /**
@@ -369,7 +359,7 @@ export class HeaderCustomizer extends RE6Module {
     }
 
     private openTabNum(event, key: string): void {
-        const tabs = HeaderCustomizer.getInstance().$menu.find("li > a");
+        const tabs = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).$menu.find("li > a");
         if (parseInt(key) > tabs.length) return;
         tabs[parseInt(key) - 1].click();
     }

--- a/src/js/modules/general/HeaderCustomizer.ts
+++ b/src/js/modules/general/HeaderCustomizer.ts
@@ -3,7 +3,7 @@ import { RE6Module, Settings } from "../../components/RE6Module";
 import { User } from "../../components/data/User";
 import { Form } from "../../components/structure/Form";
 import { Page } from "../../components/data/Page";
-import { SettingsController } from "./SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 /**
  * HeaderCustomizer  
@@ -359,7 +359,7 @@ export class HeaderCustomizer extends RE6Module {
     }
 
     private openTabNum(event, key: string): void {
-        const tabs = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).$menu.find("li > a");
+        const tabs = ModuleController.getWithType<HeaderCustomizer>(HeaderCustomizer).$menu.find("li > a");
         if (parseInt(key) > tabs.length) return;
         tabs[parseInt(key) - 1].click();
     }

--- a/src/js/modules/general/HeaderCustomizer.ts
+++ b/src/js/modules/general/HeaderCustomizer.ts
@@ -359,7 +359,7 @@ export class HeaderCustomizer extends RE6Module {
     }
 
     private openTabNum(event, key: string): void {
-        const tabs = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).$menu.find("li > a");
+        const tabs = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).$menu.find("li > a");
         if (parseInt(key) > tabs.length) return;
         tabs[parseInt(key) - 1].click();
     }

--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -11,11 +11,9 @@ declare const GM_getResourceText;
  */
 export class Miscellaneous extends RE6Module {
 
-    private static instance: Miscellaneous;
-
     private redesignStylesheet: JQuery<HTMLElement>;
 
-    private constructor() {
+    public constructor() {
         super();
         this.registerHotkeys(
             { keys: "hotkeyFocusSearch", fnct: this.focusSearchbar },
@@ -23,15 +21,6 @@ export class Miscellaneous extends RE6Module {
             { keys: "hotkeyNewComment", fnct: this.openNewComment },
             { keys: "hotkeyEditPost", fnct: this.openEditTab },
         );
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns FormattingHelper instance
-     */
-    public static getInstance(): Miscellaneous {
-        if (this.instance == undefined) this.instance = new Miscellaneous();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -264,19 +264,19 @@ export class SettingsController extends RE6Module {
         });
 
         postsPageInput.get("general-title-symbol-fav").on("re621:form:input", (event, data) => {
-            titleCustomizer.pushSettings("symbol-fav", data);
+            titleCustomizer.pushSettings("symbolFav", data);
             if (titleCustomizer.isInitialized())
                 titleCustomizer.refreshPageTitle();
         });
 
         postsPageInput.get("general-title-symbol-voteup").on("re621:form:input", (event, data) => {
-            titleCustomizer.pushSettings("symbol-voteup", data);
+            titleCustomizer.pushSettings("symbolVoteup", data);
             if (titleCustomizer.isInitialized())
                 titleCustomizer.refreshPageTitle();
         });
 
         postsPageInput.get("general-title-symbol-votedown").on("re621:form:input", (event, data) => {
-            titleCustomizer.pushSettings("symbol-votedown", data);
+            titleCustomizer.pushSettings("symbolVotedown", data);
             if (titleCustomizer.isInitialized())
                 titleCustomizer.refreshPageTitle();
         });

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -89,7 +89,7 @@ export class SettingsController {
      * @todo any parameter is not correct here but I couldn't figure the right types out
      *  { new(): RE6Module } works to access constructor name but not static methods
      */
-    public static registerModule<T>(moduleClass: any): void {
+    public static registerModule(moduleClass: any): void {
         const moduleInstance = moduleClass.getInstance();
         moduleInstance.create();
         this.getInstance().modules.set(moduleClass.prototype.constructor.name, moduleInstance);

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -28,12 +28,12 @@ export class SettingsController {
 
     private modules: Map<string, RE6Module> = new Map();
 
-    private constructor() { return; }
+    public constructor() { return; }
 
     public init(): void {
 
         // Create a button in the header
-        const addSettingsButton = HeaderCustomizer.getInstance().createTabElement({
+        const addSettingsButton = this.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-wrench"></i>`,
             parent: "menu.extra",
             class: "float-right",
@@ -86,29 +86,41 @@ export class SettingsController {
     /**
      * Registers the module so that its settings could be changed
      * @param module Module to register
+     * @todo any parameter is not correct here but I couldn't figure the right types out
+     *  { new(): RE6Module } works to access constructor name but not static methods
      */
-    public static registerModule(...moduleList: RE6Module[]): void {
-        for (const module of moduleList) {
-            this.getInstance().modules.set(module.getPrefix(), module);
-        }
+    public static registerModule<T>(moduleClass: any): void {
+        this.getInstance().modules.set(moduleClass.prototype.constructor.name, moduleClass.getInstance());
+    }
+
+    /**
+     * Returns a previously registered module with the specified class
+     * @param moduleClass Module class
+     */
+    public static getModule<T extends RE6Module>(moduleClass: { new(): T }): T {
+        return this.getInstance().modules.get(moduleClass.prototype.constructor.name) as T;
+    }
+
+    private getModuleByName(name: string): RE6Module {
+        return this.modules.get(name);
     }
 
     /**
      * Returns a previously registered module with the specified name
      * @param moduleName Module name
      */
-    public static getModule(moduleName: string): RE6Module {
-        return this.getInstance().modules.get(moduleName);
+    public getModule<T extends RE6Module>(moduleClass: { new(): T }): T {
+        return this.modules.get(moduleClass.prototype.constructor.name) as T;
     }
 
     /** Create the DOM for the Title Customizer page */
     private createTabPostsPage(): Form {
-        const titleCustomizer = this.modules.get("TitleCustomizer");
-        const downloadCustomizer = this.modules.get("DownloadCustomizer");
-        const miscellaneous = this.modules.get("Miscellaneous");
-        const postViewer = this.modules.get("PostViewer");
-        const formattingManager = this.modules.get("FormattingManager");
-        const blacklistEnhancer = this.modules.get("BlacklistEnhancer");
+        const titleCustomizer = this.getModule<TitleCustomizer>(TitleCustomizer);
+        const downloadCustomizer = this.getModule<DownloadCustomizer>(DownloadCustomizer);
+        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
+        const postViewer = this.getModule<PostViewer>(PostViewer);
+        const formattingManager = this.getModule<FormattingManager>(FormattingManager);
+        const blacklistEnhancer = this.getModule<BlacklistEnhancer>(BlacklistEnhancer);
 
         const templateIcons = new Form(
             { id: "title-template-icons", columns: 2, },
@@ -274,12 +286,12 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabPostsPage(form: Form): void {
-        const titleCustomizer = this.modules.get("TitleCustomizer") as TitleCustomizer;
-        const downloadCustomizer = this.modules.get("DownloadCustomizer") as DownloadCustomizer;
-        const miscellaneous = this.modules.get("Miscellaneous") as Miscellaneous;
-        const postViewer = this.modules.get("PostViewer") as PostViewer;
-        const formattingManager = this.modules.get("FormattingManager") as FormattingManager;
-        const blacklistEnhancer = this.modules.get("BlacklistEnhancer") as BlacklistEnhancer;
+        const titleCustomizer = this.getModule<TitleCustomizer>(TitleCustomizer);
+        const downloadCustomizer = this.getModule<DownloadCustomizer>(DownloadCustomizer);
+        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
+        const postViewer = this.getModule<PostViewer>(PostViewer);
+        const formattingManager = this.getModule<FormattingManager>(FormattingManager);
+        const blacklistEnhancer = this.getModule<BlacklistEnhancer>(BlacklistEnhancer);
         const postsPageInput = form.getInputList();
 
         // General
@@ -340,11 +352,11 @@ export class SettingsController {
 
     /** Creates the DOM for the hotkey settings page */
     private createTabHotkeys(): Form {
-        const postViewer = this.modules.get("PostViewer");
-        const poolNavigator = this.modules.get("PoolNavigator");
-        const imageScaler = this.modules.get("ImageScaler");
-        const miscellaneous = this.modules.get("Miscellaneous");
-        const headerCustomizer = this.modules.get("HeaderCustomizer");
+        const postViewer = this.getModule<TitleCustomizer>(TitleCustomizer);
+        const poolNavigator = this.getModule<PoolNavigator>(PoolNavigator);
+        const imageScaler = this.getModule<ImageScaler>(ImageScaler);
+        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
+        const headerCustomizer = this.getModule<HeaderCustomizer>(HeaderCustomizer);
 
         function createLabel(settingsKey: string, label: string): FormElement {
             return {
@@ -503,11 +515,11 @@ export class SettingsController {
      */
     private handleTabHotkeys(form: Form): void {
         const hotkeyFormInput = form.getInputList();
-        const postViewer = this.modules.get("PostViewer") as PostViewer;
-        const poolNavigator = this.modules.get("PoolNavigator") as PoolNavigator;
-        const imageScaler = this.modules.get("ImageScaler") as ImageScaler;
-        const miscellaneous = this.modules.get("Miscellaneous") as Miscellaneous;
-        const headerCustomizer = this.modules.get("HeaderCustomizer") as HeaderCustomizer;
+        const postViewer = this.getModule<PostViewer>(PostViewer);
+        const poolNavigator = this.getModule<PoolNavigator>(PoolNavigator);
+        const imageScaler = this.getModule<ImageScaler>(ImageScaler);
+        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
+        const headerCustomizer = this.getModule<HeaderCustomizer>(HeaderCustomizer);
 
         /** Creates a listener for the hotkey input */
         function createListener(module: RE6Module, settingsKey: string, bindings = 1): void {
@@ -566,7 +578,7 @@ export class SettingsController {
 
     /** Creates the DOM for the miscellaneous settings page */
     private createTabMiscellaneous(): Form {
-        const module = this.modules.get("Miscellaneous") as Miscellaneous;
+        const module = this.getModule<Miscellaneous>(Miscellaneous);
 
         // Create the settings form
         const form = new Form(
@@ -698,7 +710,7 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabMiscellaneous(form: Form): void {
-        const miscModule = this.modules.get("Miscellaneous") as Miscellaneous;
+        const miscModule = this.getModule<Miscellaneous>(Miscellaneous);
         const miscFormInput = form.getInputList();
 
         miscFormInput.get("misc-redesign-fixes").on("re621:form:input", (event, data) => {
@@ -880,7 +892,7 @@ export class SettingsController {
         const inputs = form.getInputList("checkbox");
 
         for (const formName of inputs.keys()) {
-            const module = this.modules.get(formName.split("-")[0]);
+            const module = this.getModuleByName(formName.split("-")[0]);
 
             inputs.get(formName).on("re621:form:input", (event, data) => {
                 module.pushSettings("enabled", data);

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -33,7 +33,7 @@ export class SettingsController {
     public init(): void {
 
         // Create a button in the header
-        const addSettingsButton = this.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        const addSettingsButton = this.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-wrench"></i>`,
             parent: "menu.extra",
             class: "float-right",
@@ -97,8 +97,12 @@ export class SettingsController {
      * Returns a previously registered module with the specified class
      * @param moduleClass Module class
      */
-    public static getModule<T extends RE6Module>(moduleClass: { new(): T }): T {
-        return this.getInstance().modules.get(moduleClass.prototype.constructor.name) as T;
+    public static getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
+        return this.getInstance().getModuleWithType(moduleClass) as T;
+    }
+
+    public static getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
+        return this.getInstance().getModuleNoType(moduleClass);
     }
 
     private getModuleByName(name: string): RE6Module {
@@ -109,18 +113,26 @@ export class SettingsController {
      * Returns a previously registered module with the specified name
      * @param moduleName Module name
      */
-    public getModule<T extends RE6Module>(moduleClass: { new(): T }): T {
+    public getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
         return this.modules.get(moduleClass.prototype.constructor.name) as T;
+    }
+
+    /**
+     * Returns a previously registered module with the specified name
+     * @param moduleName Module name
+     */
+    public getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
+        return this.modules.get(moduleClass.prototype.constructor.name);
     }
 
     /** Create the DOM for the Title Customizer page */
     private createTabPostsPage(): Form {
-        const titleCustomizer = this.getModule<TitleCustomizer>(TitleCustomizer);
-        const downloadCustomizer = this.getModule<DownloadCustomizer>(DownloadCustomizer);
-        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
-        const postViewer = this.getModule<PostViewer>(PostViewer);
-        const formattingManager = this.getModule<FormattingManager>(FormattingManager);
-        const blacklistEnhancer = this.getModule<BlacklistEnhancer>(BlacklistEnhancer);
+        const titleCustomizer = this.getModuleNoType(TitleCustomizer);
+        const downloadCustomizer = this.getModuleNoType(DownloadCustomizer);
+        const miscellaneous = this.getModuleNoType(Miscellaneous);
+        const postViewer = this.getModuleNoType(PostViewer);
+        const formattingManager = this.getModuleNoType(FormattingManager);
+        const blacklistEnhancer = this.getModuleNoType(BlacklistEnhancer);
 
         const templateIcons = new Form(
             { id: "title-template-icons", columns: 2, },
@@ -286,12 +298,12 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabPostsPage(form: Form): void {
-        const titleCustomizer = this.getModule<TitleCustomizer>(TitleCustomizer);
-        const downloadCustomizer = this.getModule<DownloadCustomizer>(DownloadCustomizer);
-        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
-        const postViewer = this.getModule<PostViewer>(PostViewer);
-        const formattingManager = this.getModule<FormattingManager>(FormattingManager);
-        const blacklistEnhancer = this.getModule<BlacklistEnhancer>(BlacklistEnhancer);
+        const titleCustomizer = this.getModuleWithType<TitleCustomizer>(TitleCustomizer);
+        const downloadCustomizer = this.getModuleWithType<DownloadCustomizer>(DownloadCustomizer);
+        const miscellaneous = this.getModuleNoType(Miscellaneous);
+        const postViewer = this.getModuleNoType(PostViewer);
+        const formattingManager = this.getModuleNoType(FormattingManager);
+        const blacklistEnhancer = this.getModuleNoType(BlacklistEnhancer);
         const postsPageInput = form.getInputList();
 
         // General
@@ -352,11 +364,11 @@ export class SettingsController {
 
     /** Creates the DOM for the hotkey settings page */
     private createTabHotkeys(): Form {
-        const postViewer = this.getModule<TitleCustomizer>(TitleCustomizer);
-        const poolNavigator = this.getModule<PoolNavigator>(PoolNavigator);
-        const imageScaler = this.getModule<ImageScaler>(ImageScaler);
-        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
-        const headerCustomizer = this.getModule<HeaderCustomizer>(HeaderCustomizer);
+        const postViewer = this.getModuleNoType(PostViewer);
+        const poolNavigator = this.getModuleNoType(PoolNavigator);
+        const imageScaler = this.getModuleNoType(ImageScaler);
+        const miscellaneous = this.getModuleNoType(Miscellaneous);
+        const headerCustomizer = this.getModuleNoType(HeaderCustomizer);
 
         function createLabel(settingsKey: string, label: string): FormElement {
             return {
@@ -515,11 +527,11 @@ export class SettingsController {
      */
     private handleTabHotkeys(form: Form): void {
         const hotkeyFormInput = form.getInputList();
-        const postViewer = this.getModule<PostViewer>(PostViewer);
-        const poolNavigator = this.getModule<PoolNavigator>(PoolNavigator);
-        const imageScaler = this.getModule<ImageScaler>(ImageScaler);
-        const miscellaneous = this.getModule<Miscellaneous>(Miscellaneous);
-        const headerCustomizer = this.getModule<HeaderCustomizer>(HeaderCustomizer);
+        const postViewer = this.getModuleNoType(PostViewer);
+        const poolNavigator = this.getModuleNoType(PoolNavigator);
+        const imageScaler = this.getModuleNoType(ImageScaler);
+        const miscellaneous = this.getModuleNoType(Miscellaneous);
+        const headerCustomizer = this.getModuleNoType(HeaderCustomizer);
 
         /** Creates a listener for the hotkey input */
         function createListener(module: RE6Module, settingsKey: string, bindings = 1): void {
@@ -578,7 +590,7 @@ export class SettingsController {
 
     /** Creates the DOM for the miscellaneous settings page */
     private createTabMiscellaneous(): Form {
-        const module = this.getModule<Miscellaneous>(Miscellaneous);
+        const module = this.getModuleWithType<Miscellaneous>(Miscellaneous);
 
         // Create the settings form
         const form = new Form(
@@ -710,7 +722,7 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabMiscellaneous(form: Form): void {
-        const miscModule = this.getModule<Miscellaneous>(Miscellaneous);
+        const miscModule = this.getModuleWithType<Miscellaneous>(Miscellaneous);
         const miscFormInput = form.getInputList();
 
         miscFormInput.get("misc-redesign-fixes").on("re621:form:input", (event, data) => {

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -90,7 +90,9 @@ export class SettingsController {
      *  { new(): RE6Module } works to access constructor name but not static methods
      */
     public static registerModule<T>(moduleClass: any): void {
-        this.getInstance().modules.set(moduleClass.prototype.constructor.name, moduleClass.getInstance());
+        const moduleInstance = moduleClass.getInstance();
+        moduleInstance.create();
+        this.getInstance().modules.set(moduleClass.prototype.constructor.name, moduleInstance);
     }
 
     /**

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -549,7 +549,7 @@ export class SettingsController {
         const headerCustomizer = this.getModuleNoType(HeaderCustomizer);
 
         /** Creates a listener for the hotkey input */
-        function createListener(module: RE6Module, settingsKey: string, bindings = 1): void {
+        function createListener(module: RE6Module, settingsKey: string, bindings = 2): void {
             for (let i = 0; i < bindings; i++) {
                 hotkeyFormInput.get(settingsKey + "-input-" + i).on("re621:form:input", (event, newKey, oldKey) => {
                     if (i === 0) {
@@ -570,37 +570,37 @@ export class SettingsController {
         }
 
         // Listing
-        createListener(miscellaneous, "hotkeyFocusSearch", 2);
+        createListener(miscellaneous, "hotkeyFocusSearch");
 
         // Posts
         // - Voting
-        createListener(postViewer, "hotkeyUpvote", 2);
+        createListener(postViewer, "hotkeyUpvote");
 
-        createListener(postViewer, "hotkeyDownvote", 2);
-        createListener(postViewer, "hotkeyFavorite", 2);
+        createListener(postViewer, "hotkeyDownvote");
+        createListener(postViewer, "hotkeyFavorite");
 
         // - Navigation
-        createListener(poolNavigator, "hotkeyPrev", 2);
-        createListener(poolNavigator, "hotkeyNext", 2);
-        createListener(poolNavigator, "hotkeyCycle", 2);
+        createListener(poolNavigator, "hotkeyPrev");
+        createListener(poolNavigator, "hotkeyNext");
+        createListener(poolNavigator, "hotkeyCycle");
 
         // - Scaling
-        createListener(imageScaler, "hotkeyScale", 2);
+        createListener(imageScaler, "hotkeyScale");
 
         // Comments
-        createListener(miscellaneous, "hotkeyNewComment", 2);
-        createListener(miscellaneous, "hotkeyEditPost", 2);
+        createListener(miscellaneous, "hotkeyNewComment");
+        createListener(miscellaneous, "hotkeyEditPost");
 
         // Tabs
-        createListener(headerCustomizer, "hotkeyTab1", 2);
-        createListener(headerCustomizer, "hotkeyTab2", 2);
-        createListener(headerCustomizer, "hotkeyTab3", 2);
-        createListener(headerCustomizer, "hotkeyTab4", 2);
-        createListener(headerCustomizer, "hotkeyTab5", 2);
-        createListener(headerCustomizer, "hotkeyTab6", 2);
-        createListener(headerCustomizer, "hotkeyTab7", 2);
-        createListener(headerCustomizer, "hotkeyTab8", 2);
-        createListener(headerCustomizer, "hotkeyTab9", 2);
+        createListener(headerCustomizer, "hotkeyTab1");
+        createListener(headerCustomizer, "hotkeyTab2");
+        createListener(headerCustomizer, "hotkeyTab3");
+        createListener(headerCustomizer, "hotkeyTab4");
+        createListener(headerCustomizer, "hotkeyTab5");
+        createListener(headerCustomizer, "hotkeyTab6");
+        createListener(headerCustomizer, "hotkeyTab7");
+        createListener(headerCustomizer, "hotkeyTab8");
+        createListener(headerCustomizer, "hotkeyTab9");
     }
 
     /** Creates the DOM for the miscellaneous settings page */

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -337,11 +337,11 @@ export class SettingsController {
         });
 
         postsPageInput.get("actions-votefavorite").on("re621:form:input", (event, data) => {
-            postViewer.pushSettings("upvote_on_favorite", data);
+            postViewer.pushSettings("upvoteOnFavorite", data);
         });
 
         postsPageInput.get("actions-submit-hotkey").on("re621:form:input", (event, data) => {
-            formattingManager.pushSettings("hotkey_submit_active", data);
+            formattingManager.pushSettings("hotkeySubmitActive", data);
         });
 
         // Blacklist

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -97,31 +97,44 @@ export class SettingsController {
 
     /**
      * Returns a previously registered module with the specified class
+     * This simply calls the non static variant, making the use in this class a bit more convinien
      * @param moduleClass Module class
+     * @returns the module interpreted as T (which must extend the RE6Module class)
      */
     public static getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
         return this.getInstance().getModuleWithType(moduleClass) as T;
     }
 
+    /**
+     * Same as getModuleWithType except that it returns it as a RE6Module
+     * This simply calls the non static variant, making the use in this class a bit more convinien
+     * @param moduleClass 
+     * @returns RE6Module instance
+     */
     public static getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
         return this.getInstance().getModuleNoType(moduleClass);
     }
 
+    /**
+     * Gets a module without a specific tpye from the passed class name
+     */
     private getModuleByName(name: string): RE6Module {
         return this.modules.get(name);
     }
 
     /**
-     * Returns a previously registered module with the specified name
-     * @param moduleName Module name
+     * Returns a previously registered module with the specified class
+     * @param moduleClass Module class
+     * @returns the module interpreted as T (which must extend the RE6Module class)
      */
     public getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
         return this.modules.get(moduleClass.prototype.constructor.name) as T;
     }
 
     /**
-     * Returns a previously registered module with the specified name
-     * @param moduleName Module name
+     * Same as getModuleWithType except that it returns it as a RE6Module
+     * @param moduleClass 
+     * @returns RE6Module instance
      */
     public getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
         return this.modules.get(moduleClass.prototype.constructor.name);

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -102,7 +102,7 @@ export class SettingsController {
      * @returns the module interpreted as T (which must extend the RE6Module class)
      */
     public static getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
-        return this.getInstance().getModuleWithType(moduleClass) as T;
+        return this.getInstance().getModuleWithType<T>(moduleClass);
     }
 
     /**
@@ -116,19 +116,12 @@ export class SettingsController {
     }
 
     /**
-     * Gets a module without a specific tpye from the passed class name
-     */
-    private getModuleByName(name: string): RE6Module {
-        return this.modules.get(name);
-    }
-
-    /**
      * Returns a previously registered module with the specified class
      * @param moduleClass Module class
      * @returns the module interpreted as T (which must extend the RE6Module class)
      */
     public getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
-        return this.modules.get(moduleClass.prototype.constructor.name) as T;
+        return this.getModuleNoType(moduleClass) as T;
     }
 
     /**
@@ -137,7 +130,14 @@ export class SettingsController {
      * @returns RE6Module instance
      */
     public getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
-        return this.modules.get(moduleClass.prototype.constructor.name);
+        return this.getModuleByName(moduleClass.prototype.constructor.name)
+    }
+
+    /**
+     * Gets a module without a specific tpye from the passed class name
+     */
+    private getModuleByName(name: string): RE6Module {
+        return this.modules.get(name);
     }
 
     /** Create the DOM for the Title Customizer page */

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -17,23 +17,18 @@ import { FormattingManager } from "./FormattingHelper";
 import { BlacklistEnhancer } from "../search/BlacklistEnhancer";
 import { PoolNavigator } from "../post/PoolNavigator";
 import { ImageScaler } from "../post/ImageScaler";
+import { ModuleController } from "../../components/ModuleController";
 
 /**
  * SettingsController  
  * Interface for accessing and changing project settings
  */
-export class SettingsController {
+export class SettingsController extends RE6Module {
 
-    private static instance: SettingsController;
-
-    private modules: Map<string, RE6Module> = new Map();
-
-    public constructor() { return; }
-
-    public init(): void {
+    public create(): void {
 
         // Create a button in the header
-        const addSettingsButton = this.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        const addSettingsButton = ModuleController.getWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-wrench"></i>`,
             parent: "menu.extra",
             class: "float-right",
@@ -74,80 +69,14 @@ export class SettingsController {
         this.handleTabMiscellaneous(miscSettingsTab);
     }
 
-    /**
-     * Returns a singleton instance of the SettingsController
-     * @returns SettingsController instance
-     */
-    public static getInstance(): SettingsController {
-        if (this.instance == undefined) { this.instance = new SettingsController(); }
-        return this.instance;
-    }
-
-    /**
-     * Registers the module so that its settings could be changed
-     * @param module Module to register
-     * @todo any parameter is not correct here but I couldn't figure the right types out
-     *  { new(): RE6Module } works to access constructor name but not static methods
-     */
-    public static registerModule(moduleClass: any): void {
-        const moduleInstance = moduleClass.getInstance();
-        moduleInstance.create();
-        this.getInstance().modules.set(moduleClass.prototype.constructor.name, moduleInstance);
-    }
-
-    /**
-     * Returns a previously registered module with the specified class
-     * This simply calls the non static variant, making the use in this class a bit more convinien
-     * @param moduleClass Module class
-     * @returns the module interpreted as T (which must extend the RE6Module class)
-     */
-    public static getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
-        return this.getInstance().getModuleWithType<T>(moduleClass);
-    }
-
-    /**
-     * Same as getModuleWithType except that it returns it as a RE6Module
-     * This simply calls the non static variant, making the use in this class a bit more convinien
-     * @param moduleClass 
-     * @returns RE6Module instance
-     */
-    public static getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
-        return this.getInstance().getModuleNoType(moduleClass);
-    }
-
-    /**
-     * Returns a previously registered module with the specified class
-     * @param moduleClass Module class
-     * @returns the module interpreted as T (which must extend the RE6Module class)
-     */
-    public getModuleWithType<T extends RE6Module>(moduleClass: { new(): T }): T {
-        return this.getModuleNoType(moduleClass) as T;
-    }
-
-    /**
-     * Same as getModuleWithType except that it returns it as a RE6Module
-     * @param moduleClass 
-     * @returns RE6Module instance
-     */
-    public getModuleNoType(moduleClass: { new(): RE6Module }): RE6Module {
-        return this.getModuleByName(moduleClass.prototype.constructor.name)
-    }
-
-    /**
-     * Gets a module without a specific tpye from the passed class name
-     */
-    private getModuleByName(name: string): RE6Module {
-        return this.modules.get(name);
-    }
-
     /** Create the DOM for the Title Customizer page */
     private createTabPostsPage(): Form {
-        const titleCustomizer = this.getModuleNoType(TitleCustomizer);
-        const downloadCustomizer = this.getModuleNoType(DownloadCustomizer);
-        const miscellaneous = this.getModuleNoType(Miscellaneous);
-        const postViewer = this.getModuleNoType(PostViewer);
-        const formattingManager = this.getModuleNoType(FormattingManager);
-        const blacklistEnhancer = this.getModuleNoType(BlacklistEnhancer);
+        const titleCustomizer = ModuleController.get(TitleCustomizer);
+        const downloadCustomizer = ModuleController.get(DownloadCustomizer);
+        const miscellaneous = ModuleController.get(Miscellaneous);
+        const postViewer = ModuleController.get(PostViewer);
+        const formattingManager = ModuleController.get(FormattingManager);
+        const blacklistEnhancer = ModuleController.get(BlacklistEnhancer);
 
         const templateIcons = new Form(
             { id: "title-template-icons", columns: 2, },
@@ -313,12 +242,12 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabPostsPage(form: Form): void {
-        const titleCustomizer = this.getModuleWithType<TitleCustomizer>(TitleCustomizer);
-        const downloadCustomizer = this.getModuleWithType<DownloadCustomizer>(DownloadCustomizer);
-        const miscellaneous = this.getModuleNoType(Miscellaneous);
-        const postViewer = this.getModuleNoType(PostViewer);
-        const formattingManager = this.getModuleNoType(FormattingManager);
-        const blacklistEnhancer = this.getModuleNoType(BlacklistEnhancer);
+        const titleCustomizer = ModuleController.getWithType<TitleCustomizer>(TitleCustomizer);
+        const downloadCustomizer = ModuleController.getWithType<DownloadCustomizer>(DownloadCustomizer);
+        const miscellaneous = ModuleController.get(Miscellaneous);
+        const postViewer = ModuleController.get(PostViewer);
+        const formattingManager = ModuleController.get(FormattingManager);
+        const blacklistEnhancer = ModuleController.get(BlacklistEnhancer);
         const postsPageInput = form.getInputList();
 
         // General
@@ -379,11 +308,11 @@ export class SettingsController {
 
     /** Creates the DOM for the hotkey settings page */
     private createTabHotkeys(): Form {
-        const postViewer = this.getModuleNoType(PostViewer);
-        const poolNavigator = this.getModuleNoType(PoolNavigator);
-        const imageScaler = this.getModuleNoType(ImageScaler);
-        const miscellaneous = this.getModuleNoType(Miscellaneous);
-        const headerCustomizer = this.getModuleNoType(HeaderCustomizer);
+        const postViewer = ModuleController.get(PostViewer);
+        const poolNavigator = ModuleController.get(PoolNavigator);
+        const imageScaler = ModuleController.get(ImageScaler);
+        const miscellaneous = ModuleController.get(Miscellaneous);
+        const headerCustomizer = ModuleController.get(HeaderCustomizer);
 
         function createLabel(settingsKey: string, label: string): FormElement {
             return {
@@ -542,11 +471,11 @@ export class SettingsController {
      */
     private handleTabHotkeys(form: Form): void {
         const hotkeyFormInput = form.getInputList();
-        const postViewer = this.getModuleNoType(PostViewer);
-        const poolNavigator = this.getModuleNoType(PoolNavigator);
-        const imageScaler = this.getModuleNoType(ImageScaler);
-        const miscellaneous = this.getModuleNoType(Miscellaneous);
-        const headerCustomizer = this.getModuleNoType(HeaderCustomizer);
+        const postViewer = ModuleController.get(PostViewer);
+        const poolNavigator = ModuleController.get(PoolNavigator);
+        const imageScaler = ModuleController.get(ImageScaler);
+        const miscellaneous = ModuleController.get(Miscellaneous);
+        const headerCustomizer = ModuleController.get(HeaderCustomizer);
 
         /** Creates a listener for the hotkey input */
         function createListener(module: RE6Module, settingsKey: string, bindings = 2): void {
@@ -605,7 +534,7 @@ export class SettingsController {
 
     /** Creates the DOM for the miscellaneous settings page */
     private createTabMiscellaneous(): Form {
-        const module = this.getModuleWithType<Miscellaneous>(Miscellaneous);
+        const module = ModuleController.getWithType<Miscellaneous>(Miscellaneous);
 
         // Create the settings form
         const form = new Form(
@@ -737,7 +666,7 @@ export class SettingsController {
      * @param form Miscellaneous settings form
      */
     private handleTabMiscellaneous(form: Form): void {
-        const miscModule = this.getModuleWithType<Miscellaneous>(Miscellaneous);
+        const miscModule = ModuleController.getWithType<Miscellaneous>(Miscellaneous);
         const miscFormInput = form.getInputList();
 
         miscFormInput.get("misc-redesign-fixes").on("re621:form:input", (event, data) => {
@@ -860,7 +789,7 @@ export class SettingsController {
     }
 
     private createModuleStatus(): Form {
-        const modules = this.modules;
+        const modules = ModuleController.getAll();
 
         function createInput(moduleName: string, label: string): FormElement {
             const module = modules.get(moduleName);
@@ -919,7 +848,7 @@ export class SettingsController {
         const inputs = form.getInputList("checkbox");
 
         for (const formName of inputs.keys()) {
-            const module = this.getModuleByName(formName.split("-")[0]);
+            const module = ModuleController.getByName(formName.split("-")[0]);
 
             inputs.get(formName).on("re621:form:input", (event, data) => {
                 module.pushSettings("enabled", data);

--- a/src/js/modules/general/ThemeCustomizer.ts
+++ b/src/js/modules/general/ThemeCustomizer.ts
@@ -60,7 +60,7 @@ export class ThemeCustomizer extends RE6Module {
         super.create();
 
         // === Create a button in the header
-        const addTabButton = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        const addTabButton = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-paint-brush"></i>`,
             parent: "menu.extra",
             controls: false,

--- a/src/js/modules/general/ThemeCustomizer.ts
+++ b/src/js/modules/general/ThemeCustomizer.ts
@@ -6,6 +6,7 @@ import { HeaderCustomizer } from "./HeaderCustomizer";
 import { Modal } from "../../components/structure/Modal";
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Form } from "../../components/structure/Form";
+import { SettingsController } from "./SettingsController";
 
 const THEME_MAIN = [
     { value: "hexagon", name: "Hexagon" },
@@ -31,21 +32,10 @@ const THEME_EXTRA = [
  */
 export class ThemeCustomizer extends RE6Module {
 
-    private static instance: ThemeCustomizer;
-
     private themeCustomizerForm: Form;
 
-    private constructor() {
+    public constructor() {
         super();
-    }
-
-    /**
-     * Returns a singleton instance of the SettingsController
-     * @returns ThemeCustomizer instance
-     */
-    public static getInstance(): ThemeCustomizer {
-        if (this.instance == undefined) this.instance = new ThemeCustomizer();
-        return this.instance;
     }
 
     /**
@@ -70,7 +60,7 @@ export class ThemeCustomizer extends RE6Module {
         super.create();
 
         // === Create a button in the header
-        const addTabButton = HeaderCustomizer.getInstance().createTabElement({
+        const addTabButton = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-paint-brush"></i>`,
             parent: "menu.extra",
             controls: false,

--- a/src/js/modules/general/ThemeCustomizer.ts
+++ b/src/js/modules/general/ThemeCustomizer.ts
@@ -34,10 +34,6 @@ export class ThemeCustomizer extends RE6Module {
 
     private themeCustomizerForm: Form;
 
-    public constructor() {
-        super();
-    }
-
     /**
      * Returns a set of default settings values
      * @returns Default settings

--- a/src/js/modules/general/ThemeCustomizer.ts
+++ b/src/js/modules/general/ThemeCustomizer.ts
@@ -6,7 +6,7 @@ import { HeaderCustomizer } from "./HeaderCustomizer";
 import { Modal } from "../../components/structure/Modal";
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Form } from "../../components/structure/Form";
-import { SettingsController } from "./SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 const THEME_MAIN = [
     { value: "hexagon", name: "Hexagon" },
@@ -56,7 +56,7 @@ export class ThemeCustomizer extends RE6Module {
         super.create();
 
         // === Create a button in the header
-        const addTabButton = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        const addTabButton = ModuleController.getWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-paint-brush"></i>`,
             parent: "menu.extra",
             controls: false,

--- a/src/js/modules/post/DownloadCustomizer.ts
+++ b/src/js/modules/post/DownloadCustomizer.ts
@@ -10,22 +10,11 @@ declare const GM_download;
  */
 export class DownloadCustomizer extends RE6Module {
 
-    private static instance: DownloadCustomizer;
-
     private post: ViewingPost;
     private link: JQuery<HTMLElement>;
 
-    private constructor() {
+    public constructor() {
         super(PageDefintion.post);
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns DownloadCustomizer instance
-     */
-    public static getInstance(): DownloadCustomizer {
-        if (this.instance == undefined) this.instance = new DownloadCustomizer();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/post/ImageScaler.ts
+++ b/src/js/modules/post/ImageScaler.ts
@@ -2,6 +2,7 @@ import { RE6Module, Settings } from "../../components/RE6Module";
 import { Post } from "../../components/data/Post";
 import { Form } from "../../components/structure/Form";
 import { PageDefintion } from "../../components/data/Page";
+import { SettingsController } from "../general/SettingsController";
 
 declare const Danbooru;
 
@@ -17,27 +18,16 @@ const IMAGE_SIZES = [
  */
 export class ImageScaler extends RE6Module {
 
-    private static instance: ImageScaler;
-
     private post: Post;
     private image: JQuery<HTMLElement>;
 
     private resizeSelector: JQuery<HTMLElement>;
 
-    constructor() {
+    public constructor() {
         super(PageDefintion.post);
         this.registerHotkeys(
             { keys: "hotkeyScale", fnct: () => { this.setScale(); } }
         );
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns BlacklistToggler instance
-     */
-    public static getInstance(): ImageScaler {
-        if (this.instance == undefined) this.instance = new ImageScaler();
-        return this.instance;
     }
 
     /**
@@ -109,7 +99,7 @@ export class ImageScaler extends RE6Module {
      * @param save Set to false to prevent saving the scale to settings
      */
     private setScale(size = "", save = true): void {
-        const selector = ImageScaler.getInstance().resizeSelector;
+        const selector = SettingsController.getModule<ImageScaler>(ImageScaler).resizeSelector;
         if (size === "") {
             const $next = selector.find("option:selected").next();
             if ($next.length > 0) { size = $next.val() + ""; }

--- a/src/js/modules/post/ImageScaler.ts
+++ b/src/js/modules/post/ImageScaler.ts
@@ -2,7 +2,7 @@ import { RE6Module, Settings } from "../../components/RE6Module";
 import { Post } from "../../components/data/Post";
 import { Form } from "../../components/structure/Form";
 import { PageDefintion } from "../../components/data/Page";
-import { SettingsController } from "../general/SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 declare const Danbooru;
 
@@ -99,7 +99,7 @@ export class ImageScaler extends RE6Module {
      * @param save Set to false to prevent saving the scale to settings
      */
     private setScale(size = "", save = true): void {
-        const selector = SettingsController.getModuleWithType<ImageScaler>(ImageScaler).resizeSelector;
+        const selector = ModuleController.getWithType<ImageScaler>(ImageScaler).resizeSelector;
         if (size === "") {
             const $next = selector.find("option:selected").next();
             if ($next.length > 0) { size = $next.val() + ""; }

--- a/src/js/modules/post/ImageScaler.ts
+++ b/src/js/modules/post/ImageScaler.ts
@@ -99,7 +99,7 @@ export class ImageScaler extends RE6Module {
      * @param save Set to false to prevent saving the scale to settings
      */
     private setScale(size = "", save = true): void {
-        const selector = SettingsController.getModule<ImageScaler>(ImageScaler).resizeSelector;
+        const selector = SettingsController.getModuleWithType<ImageScaler>(ImageScaler).resizeSelector;
         if (size === "") {
             const $next = selector.find("option:selected").next();
             if ($next.length > 0) { size = $next.val() + ""; }

--- a/src/js/modules/post/PoolNavigator.ts
+++ b/src/js/modules/post/PoolNavigator.ts
@@ -48,7 +48,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Loops through available navbars */
     private cycleNavbars(): void {
-        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
 
@@ -63,7 +63,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Emulates a click on the "next" button */
     private triggerNextPost(): void {
-        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
         if (navbars.length == 0) return;
@@ -72,7 +72,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Emulates a click on the "prev" button */
     private triggerPrevPost(): void {
-        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
         if (navbars.length == 0) return;

--- a/src/js/modules/post/PoolNavigator.ts
+++ b/src/js/modules/post/PoolNavigator.ts
@@ -1,6 +1,6 @@
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { PageDefintion } from "../../components/data/Page";
-import { SettingsController } from "../general/SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 export class PoolNavigator extends RE6Module {
 
@@ -48,7 +48,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Loops through available navbars */
     private cycleNavbars(): void {
-        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
+        const poolNavigator = ModuleController.getWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
 
@@ -63,7 +63,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Emulates a click on the "next" button */
     private triggerNextPost(): void {
-        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
+        const poolNavigator = ModuleController.getWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
         if (navbars.length == 0) return;
@@ -72,7 +72,7 @@ export class PoolNavigator extends RE6Module {
 
     /** Emulates a click on the "prev" button */
     private triggerPrevPost(): void {
-        const poolNavigator = SettingsController.getModuleWithType<PoolNavigator>(PoolNavigator);
+        const poolNavigator = ModuleController.getWithType<PoolNavigator>(PoolNavigator);
         const navbars = poolNavigator.navbars,
             active = poolNavigator.activeNav;
         if (navbars.length == 0) return;

--- a/src/js/modules/post/PoolNavigator.ts
+++ b/src/js/modules/post/PoolNavigator.ts
@@ -1,29 +1,19 @@
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { PageDefintion } from "../../components/data/Page";
+import { SettingsController } from "../general/SettingsController";
 
 export class PoolNavigator extends RE6Module {
-
-    private static instance: PoolNavigator;
 
     private activeNav = 0;
     private navbars: PostNav[] = [];
 
-    private constructor() {
+    public constructor() {
         super(PageDefintion.post);
         this.registerHotkeys(
             { keys: "hotkeyCycle", fnct: this.cycleNavbars },
             { keys: "hotkeyNext", fnct: this.triggerNextPost },
             { keys: "hotkeyPrev", fnct: this.triggerPrevPost },
         );
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns FormattingHelper instance
-     */
-    public static getInstance(): PoolNavigator {
-        if (this.instance == undefined) this.instance = new PoolNavigator();
-        return this.instance;
     }
 
     /**
@@ -58,30 +48,33 @@ export class PoolNavigator extends RE6Module {
 
     /** Loops through available navbars */
     private cycleNavbars(): void {
-        const navbars = PoolNavigator.getInstance().navbars,
-            active = PoolNavigator.getInstance().activeNav;
+        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const navbars = poolNavigator.navbars,
+            active = poolNavigator.activeNav;
 
         if ((active + 1) >= navbars.length) {
             navbars[0].checkbox.click();
-            PoolNavigator.getInstance().activeNav = 0;
+            poolNavigator.activeNav = 0;
         } else {
             navbars[active + 1].checkbox.click();
-            PoolNavigator.getInstance().activeNav += 1;
+            poolNavigator.activeNav += 1;
         }
     }
 
     /** Emulates a click on the "next" button */
     private triggerNextPost(): void {
-        const navbars = PoolNavigator.getInstance().navbars,
-            active = PoolNavigator.getInstance().activeNav;
+        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const navbars = poolNavigator.navbars,
+            active = poolNavigator.activeNav;
         if (navbars.length == 0) return;
         navbars[active].element.find("a.next").first()[0].click();
     }
 
     /** Emulates a click on the "prev" button */
     private triggerPrevPost(): void {
-        const navbars = PoolNavigator.getInstance().navbars,
-            active = PoolNavigator.getInstance().activeNav;
+        const poolNavigator = SettingsController.getModule<PoolNavigator>(PoolNavigator);
+        const navbars = poolNavigator.navbars,
+            active = poolNavigator.activeNav;
         if (navbars.length == 0) return;
         navbars[active].element.find("a.prev").first()[0].click();
     }

--- a/src/js/modules/post/PostViewer.ts
+++ b/src/js/modules/post/PostViewer.ts
@@ -8,25 +8,15 @@ import { PageDefintion } from "../../components/data/Page";
  */
 export class PostViewer extends RE6Module {
 
-    private static instance: PostViewer;
     private post: ViewingPost;
 
-    private constructor() {
+    public constructor() {
         super(PageDefintion.post);
         this.registerHotkeys(
             { keys: "hotkeyUpvote", fnct: this.triggerUpvote },
             { keys: "hotkeyDownvote", fnct: this.triggerDownvote },
             { keys: "hotkeyFavorite", fnct: this.toggleFavorite }
         );
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns FormattingHelper instance
-     */
-    public static getInstance(): PostViewer {
-        if (this.instance == undefined) this.instance = new PostViewer();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/post/TitleCustomizer.ts
+++ b/src/js/modules/post/TitleCustomizer.ts
@@ -9,21 +9,10 @@ import { PageDefintion } from "../../components/data/Page";
  */
 export class TitleCustomizer extends RE6Module {
 
-    private static instance: TitleCustomizer;
-
     private post: ViewingPost;
 
-    private constructor() {
+    public constructor() {
         super(PageDefintion.post);
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns FormattingHelper instance
-     */
-    public static getInstance(): TitleCustomizer {
-        if (this.instance == undefined) this.instance = new TitleCustomizer();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/post/TitleCustomizer.ts
+++ b/src/js/modules/post/TitleCustomizer.ts
@@ -56,9 +56,9 @@ export class TitleCustomizer extends RE6Module {
     private parseTemplate(): string {
         let prefix = "";
         if (this.fetchSettings("symbolsEnabled")) {
-            if (this.post.getIsFaved()) { prefix += this.fetchSettings("symbol_fav"); }
-            if (this.post.getIsUpvoted()) { prefix += this.fetchSettings("symbol_voteup"); }
-            else if (this.post.getIsDownvoted()) { prefix += this.fetchSettings("symbol_votedown"); }
+            if (this.post.getIsFaved()) { prefix += this.fetchSettings("symbolFav"); }
+            if (this.post.getIsUpvoted()) { prefix += this.fetchSettings("symbolVoteup"); }
+            else if (this.post.getIsDownvoted()) { prefix += this.fetchSettings("symbolVotedown"); }
             if (prefix) prefix += " ";
         }
 

--- a/src/js/modules/search/BlacklistEnhancer.ts
+++ b/src/js/modules/search/BlacklistEnhancer.ts
@@ -3,7 +3,7 @@ import { PageDefintion } from "../../components/data/Page";
 import { Post, ViewingPost } from "../../components/data/Post";
 import { User } from "../../components/data/User";
 import { PostFilter } from "../../components/data/PostFilter";
-import { SettingsController } from "../general/SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -133,7 +133,7 @@ export class BlacklistEnhancer extends RE6Module {
         }
         await User.setSettings({ blacklisted_tags: currentBlacklist.join("\n") });
         Danbooru.notice("Done!");
-        SettingsController.getModuleWithType<User>(User).addBlacklistFilter(tag);
+        ModuleController.getWithType<User>(User).addBlacklistFilter(tag);
         this.applyBlacklist();
     }
 

--- a/src/js/modules/search/BlacklistEnhancer.ts
+++ b/src/js/modules/search/BlacklistEnhancer.ts
@@ -3,6 +3,7 @@ import { PageDefintion } from "../../components/data/Page";
 import { Post, ViewingPost } from "../../components/data/Post";
 import { User } from "../../components/data/User";
 import { PostFilter } from "../../components/data/PostFilter";
+import { SettingsController } from "../general/SettingsController";
 
 /* eslint-disable @typescript-eslint/camelcase */
 
@@ -14,23 +15,12 @@ declare const Danbooru;
  */
 export class BlacklistEnhancer extends RE6Module {
 
-    private static instance: BlacklistEnhancer;
-
     private $box: JQuery<HTMLElement>;
     private $toggle: JQuery<HTMLElement>;
     private $list: JQuery<HTMLElement>;
 
-    private constructor() {
+    public constructor() {
         super([PageDefintion.search, PageDefintion.post]);
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns BlacklistEnhancer instance
-     */
-    public static getInstance(): BlacklistEnhancer {
-        if (this.instance == undefined) this.instance = new BlacklistEnhancer();
-        return this.instance;
     }
 
     /**
@@ -143,7 +133,7 @@ export class BlacklistEnhancer extends RE6Module {
         }
         await User.setSettings({ blacklisted_tags: currentBlacklist.join("\n") });
         Danbooru.notice("Done!");
-        User.getInstance().addBlacklistFilter(tag);
+        SettingsController.getModule<User>(User).addBlacklistFilter(tag);
         this.applyBlacklist();
     }
 

--- a/src/js/modules/search/BlacklistEnhancer.ts
+++ b/src/js/modules/search/BlacklistEnhancer.ts
@@ -133,7 +133,7 @@ export class BlacklistEnhancer extends RE6Module {
         }
         await User.setSettings({ blacklisted_tags: currentBlacklist.join("\n") });
         Danbooru.notice("Done!");
-        SettingsController.getModule<User>(User).addBlacklistFilter(tag);
+        SettingsController.getModuleWithType<User>(User).addBlacklistFilter(tag);
         this.applyBlacklist();
     }
 

--- a/src/js/modules/search/InfiniteScroll.ts
+++ b/src/js/modules/search/InfiniteScroll.ts
@@ -94,8 +94,8 @@ export class InfiniteScroll extends RE6Module {
         this.isInProgress = false;
         this.$loadingIndicator.hide();
 
-        SettingsController.getModule<BlacklistEnhancer>(BlacklistEnhancer).updateSidebar();
-        SettingsController.getModule<InstantSearch>(InstantSearch).applyFilter();
+        SettingsController.getModuleWithType<BlacklistEnhancer>(BlacklistEnhancer).updateSidebar();
+        SettingsController.getModuleWithType<InstantSearch>(InstantSearch).applyFilter();
 
         this.nextPageToGet++;
     }

--- a/src/js/modules/search/InfiniteScroll.ts
+++ b/src/js/modules/search/InfiniteScroll.ts
@@ -6,7 +6,7 @@ import { PostHtml } from "../../components/api/PostHtml";
 import { InstantSearch } from "./InstantSearch";
 import { Post } from "../../components/data/Post";
 import { BlacklistEnhancer } from "./BlacklistEnhancer";
-import { SettingsController } from "../general/SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 declare const Danbooru;
 
@@ -94,8 +94,8 @@ export class InfiniteScroll extends RE6Module {
         this.isInProgress = false;
         this.$loadingIndicator.hide();
 
-        SettingsController.getModuleWithType<BlacklistEnhancer>(BlacklistEnhancer).updateSidebar();
-        SettingsController.getModuleWithType<InstantSearch>(InstantSearch).applyFilter();
+        ModuleController.getWithType<BlacklistEnhancer>(BlacklistEnhancer).updateSidebar();
+        ModuleController.getWithType<InstantSearch>(InstantSearch).applyFilter();
 
         this.nextPageToGet++;
     }

--- a/src/js/modules/search/InfiniteScroll.ts
+++ b/src/js/modules/search/InfiniteScroll.ts
@@ -6,6 +6,7 @@ import { PostHtml } from "../../components/api/PostHtml";
 import { InstantSearch } from "./InstantSearch";
 import { Post } from "../../components/data/Post";
 import { BlacklistEnhancer } from "./BlacklistEnhancer";
+import { SettingsController } from "../general/SettingsController";
 
 declare const Danbooru;
 
@@ -22,19 +23,8 @@ export class InfiniteScroll extends RE6Module {
     private isInProgress: boolean;
     private pagesLeft: boolean;
 
-    private static instance: InfiniteScroll;
-
-    private constructor() {
+    public constructor() {
         super(PageDefintion.search);
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns InfiniteScroll instance
-     */
-    public static getInstance(): InfiniteScroll {
-        if (this.instance == undefined) this.instance = new InfiniteScroll();
-        return this.instance;
     }
 
     /**
@@ -104,9 +94,9 @@ export class InfiniteScroll extends RE6Module {
         this.isInProgress = false;
         this.$loadingIndicator.hide();
 
-        BlacklistEnhancer.getInstance().updateSidebar();
+        SettingsController.getModule<BlacklistEnhancer>(BlacklistEnhancer).updateSidebar();
+        SettingsController.getModule<InstantSearch>(InstantSearch).applyFilter();
 
-        InstantSearch.getInstance().applyFilter();
         this.nextPageToGet++;
     }
 

--- a/src/js/modules/search/InstantSearch.ts
+++ b/src/js/modules/search/InstantSearch.ts
@@ -12,19 +12,8 @@ export class InstantSearch extends RE6Module {
     // TODO: this can be of type HTMLInputElememnt, but I don't know how to do that
     private $searchbox: JQuery<HTMLElement>;
 
-    private static instance: InstantSearch = new InstantSearch();
-
-    private constructor() {
+    public constructor() {
         super(PageDefintion.search);
-    }
-
-    /**
-     * Returns a singleton instance of the class
-     * @returns InstantSearch instance
-     */
-    public static getInstance(): InstantSearch {
-        if (this.instance == undefined) this.instance = new InstantSearch();
-        return this.instance;
     }
 
     /**

--- a/src/js/modules/subscriptions/ForumSubscriptions.ts
+++ b/src/js/modules/subscriptions/ForumSubscriptions.ts
@@ -29,10 +29,6 @@ export class ForumSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    public constructor() {
-        super();
-    }
-
     public getName(): string {
         return "Forums";
     }

--- a/src/js/modules/subscriptions/ForumSubscriptions.ts
+++ b/src/js/modules/subscriptions/ForumSubscriptions.ts
@@ -29,7 +29,9 @@ export class ForumSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    private static instance: ForumSubscriptions;
+    public constructor() {
+        super();
+    }
 
     public getName(): string {
         return "Forums";
@@ -92,11 +94,6 @@ export class ForumSubscriptions extends RE6Module implements Subscription {
             enabled: true,
             data: {}
         };
-    }
-
-    public static getInstance(): ForumSubscriptions {
-        if (this.instance == undefined) this.instance = new ForumSubscriptions();
-        return this.instance;
     }
 }
 

--- a/src/js/modules/subscriptions/PoolSubscriptions.ts
+++ b/src/js/modules/subscriptions/PoolSubscriptions.ts
@@ -33,7 +33,9 @@ export class PoolSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    private static instance: PoolSubscriptions;
+    public constructor() {
+        super();
+    }
 
     public getName(): string {
         return "Pools";
@@ -101,11 +103,6 @@ export class PoolSubscriptions extends RE6Module implements Subscription {
             enabled: true,
             data: {}
         };
-    }
-
-    public static getInstance(): PoolSubscriptions {
-        if (this.instance == undefined) this.instance = new PoolSubscriptions();
-        return this.instance;
     }
 }
 

--- a/src/js/modules/subscriptions/PoolSubscriptions.ts
+++ b/src/js/modules/subscriptions/PoolSubscriptions.ts
@@ -33,10 +33,6 @@ export class PoolSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    public constructor() {
-        super();
-    }
-
     public getName(): string {
         return "Pools";
     }

--- a/src/js/modules/subscriptions/SubscriptionManager.ts
+++ b/src/js/modules/subscriptions/SubscriptionManager.ts
@@ -29,7 +29,7 @@ export class SubscriptionManager extends RE6Module {
         if (!this.canInitialize()) return;
         super.create();
         // Create a button in the header
-        this.openSubsButton = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        this.openSubsButton = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-bell"></i>`,
             parent: "menu.extra",
             controls: false,

--- a/src/js/modules/subscriptions/SubscriptionManager.ts
+++ b/src/js/modules/subscriptions/SubscriptionManager.ts
@@ -98,7 +98,8 @@ export class SubscriptionManager extends RE6Module {
      * Adds a subscriber to the list of them and creates a tab for it.
      * @param instance subscriber to be queued for update check
      */
-    public static registerSubscriber(instance: Subscription): void {
+    public static register(moduleClass: any): void {
+        const instance = ModuleController.getWithType<Subscription>(moduleClass);
         const manager = this.getInstance() as SubscriptionManager;
         manager.subscribers.push(instance);
     }

--- a/src/js/modules/subscriptions/SubscriptionManager.ts
+++ b/src/js/modules/subscriptions/SubscriptionManager.ts
@@ -4,10 +4,10 @@ import { Tabbed } from "../../components/structure/Tabbed";
 import { Modal } from "../../components/structure/Modal";
 import { Subscription } from "./Subscription";
 import { Util } from "../../components/structure/Util";
+import { SettingsController } from "../general/SettingsController";
 
 export class SubscriptionManager extends RE6Module {
 
-    private static instance: SubscriptionManager;
     //should notifications be cleared once seen?
     public dismissOnUpdate = true;
     private updateInterval = 60 * 60; //1 hour, in seconds
@@ -17,6 +17,10 @@ export class SubscriptionManager extends RE6Module {
 
     public openSubsButton: HeaderTabElement;
 
+    public constructor() {
+        super();
+    }
+
     /**
      * Creates the module's structure.  
      * Should be run immediately after the constructor finishes.
@@ -25,7 +29,7 @@ export class SubscriptionManager extends RE6Module {
         if (!this.canInitialize()) return;
         super.create();
         // Create a button in the header
-        this.openSubsButton = HeaderCustomizer.getInstance().createTabElement({
+        this.openSubsButton = SettingsController.getModule<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-bell"></i>`,
             parent: "menu.extra",
             controls: false,
@@ -99,7 +103,8 @@ export class SubscriptionManager extends RE6Module {
      * @param instance subscriber to be queued for update check
      */
     public static registerSubscriber(instance: Subscription): void {
-        this.getInstance().subscribers.push(instance);
+        const manager = this.getInstance() as SubscriptionManager;
+        manager.subscribers.push(instance);
     }
 
     public static createTabContent(): JQuery<HTMLElement> {
@@ -283,12 +288,6 @@ export class SubscriptionManager extends RE6Module {
             enabled: true
         };
     }
-
-    public static getInstance(): SubscriptionManager {
-        if (this.instance == undefined) this.instance = new SubscriptionManager();
-        return this.instance;
-    }
-
 }
 
 

--- a/src/js/modules/subscriptions/SubscriptionManager.ts
+++ b/src/js/modules/subscriptions/SubscriptionManager.ts
@@ -17,10 +17,6 @@ export class SubscriptionManager extends RE6Module {
 
     public openSubsButton: HeaderTabElement;
 
-    public constructor() {
-        super();
-    }
-
     /**
      * Creates the module's structure.  
      * Should be run immediately after the constructor finishes.

--- a/src/js/modules/subscriptions/SubscriptionManager.ts
+++ b/src/js/modules/subscriptions/SubscriptionManager.ts
@@ -4,7 +4,7 @@ import { Tabbed } from "../../components/structure/Tabbed";
 import { Modal } from "../../components/structure/Modal";
 import { Subscription } from "./Subscription";
 import { Util } from "../../components/structure/Util";
-import { SettingsController } from "../general/SettingsController";
+import { ModuleController } from "../../components/ModuleController";
 
 export class SubscriptionManager extends RE6Module {
 
@@ -25,7 +25,7 @@ export class SubscriptionManager extends RE6Module {
         if (!this.canInitialize()) return;
         super.create();
         // Create a button in the header
-        this.openSubsButton = SettingsController.getModuleWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
+        this.openSubsButton = ModuleController.getWithType<HeaderCustomizer>(HeaderCustomizer).createTabElement({
             name: `<i class="fas fa-bell"></i>`,
             parent: "menu.extra",
             controls: false,

--- a/src/js/modules/subscriptions/TagSubscriptions.ts
+++ b/src/js/modules/subscriptions/TagSubscriptions.ts
@@ -28,7 +28,9 @@ export class TagSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    private static instance: TagSubscriptions;
+    public constructor() {
+        super();
+    }
 
     public getName(): string {
         return "Tags";
@@ -95,11 +97,6 @@ export class TagSubscriptions extends RE6Module implements Subscription {
             enabled: true,
             data: {}
         };
-    }
-
-    public static getInstance(): TagSubscriptions {
-        if (this.instance == undefined) this.instance = new TagSubscriptions();
-        return this.instance;
     }
 }
 

--- a/src/js/modules/subscriptions/TagSubscriptions.ts
+++ b/src/js/modules/subscriptions/TagSubscriptions.ts
@@ -28,10 +28,6 @@ export class TagSubscriptions extends RE6Module implements Subscription {
     lastUpdate: number;
     tab: JQuery<HTMLElement>;
 
-    public constructor() {
-        super();
-    }
-
     public getName(): string {
         return "Tags";
     }

--- a/src/js/modules/upload/TinyAlias.ts
+++ b/src/js/modules/upload/TinyAlias.ts
@@ -9,8 +9,6 @@ declare const Danbooru;
 
 export class TinyAlias extends RE6Module {
 
-    private static instance: TinyAlias;
-
     private $textarea: JQuery<HTMLElement>;
     private $container: JQuery<HTMLElement>;
 
@@ -20,20 +18,8 @@ export class TinyAlias extends RE6Module {
     private tagAlreadyChecked: boolean;
     private aliasData;
 
-    private constructor() {
+    public constructor() {
         super(PageDefintion.upload);
-    }
-
-    /**
-     * Returns a singleton instance of the SettingsController
-     * @returns ThemeCustomizer instance
-     */
-    public static getInstance(): TinyAlias {
-        if (this.instance === undefined) {
-            this.instance = new TinyAlias();
-            this.instance.create();
-        }
-        return this.instance;
     }
 
     /**


### PR DESCRIPTION
This is a attempt at removing all those getInstance methods and instance properties from modules.
I think it actually works really well. 

The way it's set up right now you can only get a module from something which extends RE6Module which means that there is no way to pass invalid arguments to this function, as long as the module got registered. This is a big plus in my opinion.

There is still some boilerplate in getModuleWithType in that you basically need to say two times what you want, for example `getModuleWithType<BlacklistEnhancer>(BlacklistEnhancer)`

I can't think of a way to get rid of that though. The types to have to match at least so you can't get a PostViewer as an InstantSearch.

Would fix #44 if merged.