### PR TITLE
API Wrapper Proposal

### DIFF
--- a/src/js/components/api/E621.ts
+++ b/src/js/components/api/E621.ts
@@ -80,7 +80,7 @@ class APIEndpoint {
         const queryString = [];
         keys.forEach((key) => {
             let value = query[key];
-            if (Array.isArray(value)) value = (value as string[]).join(",");
+            if (Array.isArray(value)) value = (value as string[]).join("+");
             queryString.push(encodeURIComponent(key) + "=" + encodeURIComponent(value));
         });
         return queryString.join("&");

--- a/src/js/components/api/E621.ts
+++ b/src/js/components/api/E621.ts
@@ -1,0 +1,224 @@
+
+// All endpoints must be registered here.
+// Name is irrelevant, as long as it is unique.
+// Path is the endpoint address, without https://e621.net/
+const ENDPOINT_DEFS: EndpointDefinition[] = [
+    { name: "posts", path: "posts", },
+    { name: "tags", path: "tags" },
+    { name: "tag_aliases", path: "tag_aliases" },
+    { name: "tag_implications", path: "tag_implications" },
+
+    { name: "notes", path: "notes" },
+    { name: "favorites", path: "favorites", },
+    { name: "pools", path: "pools", },
+    { name: "sets", path: "sets", },
+
+    { name: "users", path: "users" },
+    { name: "blips", path: "blips" },
+    { name: "wiki_pages", path: "wiki_pages" },
+
+    { name: "comments", path: "comments" },
+    { name: "forum_index", path: "forum_posts" },
+    { name: "forum_topics", path: "forum_topics" },
+];
+
+class APIEndpoint {
+
+    private queue: E621;
+    private path: string;
+
+    private param = "";
+
+    public constructor(queue: E621, endpoint: EndpointDefinition) {
+        this.queue = queue;
+        this.path = endpoint.path;
+    }
+
+    /**
+     * Set an endpoint parameter, if the current endpoint allows it.  
+     * For example, to GET /users/12345.json, use E621.User.spec("12345").get(...);
+     * @param param 
+     */
+    public spec(param: string): APIEndpoint {
+        this.param = param;
+        return this;
+    }
+
+    /**
+     * Send a GET request to the endpoint
+     * @param query Request query, either as a raw string or an APIQuery
+     * @param delay Optional delay override, in milliseconds
+     */
+    public async get(query: string | APIQuery, delay?: number): Promise<any> {
+        return this.queue.createRequest(this.getParsedPath(), this.queryToString(query), "GET", "", delay);
+    }
+
+    /**
+     * Send a POST request to the endpoint
+     * @param data Data to be sent with the request
+     * @param delay Optional delay override, in milliseconds
+     */
+    public async post(data: {}, delay?: number): Promise<any> {
+        return this.queue.createRequest(this.getParsedPath(), "", "POST", this.queryToString(data), delay);
+    }
+
+    /** Returns the endpoint path, accounting for the possible parameter */
+    private getParsedPath(): string {
+        if (this.param === "") return this.path + ".json";
+        const newPath = this.path + "/" + this.param;
+        this.param = "";
+        return newPath + ".json";
+    }
+
+    /** Converts APIQuery into a raw string */
+    private queryToString(query: string | APIQuery): string {
+        if (typeof query === "string") return query;
+
+        const keys = Object.keys(query);
+        if (keys.length === 0) return "";
+
+        const queryString = [];
+        keys.forEach((key) => {
+            let value = query[key];
+            if (Array.isArray(value)) value = (value as string[]).join(",");
+            queryString.push(encodeURIComponent(key) + "=" + encodeURIComponent(value));
+        });
+        return queryString.join("&");
+    }
+
+}
+
+export class E621 {
+
+    // Singleton instance, to avoid queue desynchronization
+    private static instance: E621;
+
+    // How often the script can send requests to the API, in milliseconds.
+    // It can be as low as 500ms, but to stay on the safe side, we keep it at 1000.
+    private static requestRateLimit = 1000;
+
+    // Needed to authenticate some post requests, for example when you modify user settings
+    private authToken: string;
+
+    // Request queue variables
+    private queue: QueueItem[];
+    private processing = false;
+    private requestIndex = 0;
+
+    // Endpoint Definitions
+    private endpoints = {};
+
+    // Endpoint Aliases
+    public static Posts: APIEndpoint = E621.getEndpoint("posts");
+    public static Tags: APIEndpoint = E621.getEndpoint("tags");
+    public static TagAliases: APIEndpoint = E621.getEndpoint("tag_aliases");
+    public static TagImplications: APIEndpoint = E621.getEndpoint("tag_implications");
+
+    public static Notes: APIEndpoint = E621.getEndpoint("notes");
+    public static Favorites: APIEndpoint = E621.getEndpoint("favorites");
+    public static Pools: APIEndpoint = E621.getEndpoint("pools");
+    public static Sets: APIEndpoint = E621.getEndpoint("sets");
+
+    public static Users: APIEndpoint = E621.getEndpoint("users");
+    public static Blips: APIEndpoint = E621.getEndpoint("blips");
+    public static Wiki: APIEndpoint = E621.getEndpoint("wiki_pages");
+
+    public static Comments: APIEndpoint = E621.getEndpoint("comments");
+    public static ForumPosts: APIEndpoint = E621.getEndpoint("forum_posts");
+    public static ForumTopics: APIEndpoint = E621.getEndpoint("forum_topics");
+
+    /** Constructor - should be kept private */
+    private constructor() {
+        this.authToken = $("head meta[name=csrf-token]").attr("content");
+        this.queue = [];
+        ENDPOINT_DEFS.forEach((definition) => {
+            this.endpoints[definition.name] = new APIEndpoint(this, definition);
+        });
+    }
+
+    /**
+     * Returns an endpoint by name.  
+     * Names are defined in ENDPOINT_DEFS constant
+     * @param name Endpoint name
+     */
+    private static getEndpoint(name: string): APIEndpoint {
+        if (this.instance === undefined) this.instance = new E621();
+        return this.instance.endpoints[name];
+    }
+
+    /**
+     * Adds a new request to the queue based on provided data.  
+     * This should only be called from endpoint get() or post() methods.  
+     * @param path Endpoint path, i.e. posts.json
+     * @param query Raw query string, i.e. ?tags=horse,male,solo
+     * @param method Request method, either GET or POST
+     * @param data Data to POST
+     */
+    public async createRequest(path: string, query: string, method: "GET" | "POST", data = "", delay?: number): Promise<any> {
+        if (delay === undefined) delay = E621.requestRateLimit;
+        else if (delay < 500) delay = 500;
+
+        const requestInfo: RequestInit = {
+            credentials: "include",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Header": "re621/1.0 userscript re621.github.io"
+            },
+            method: method,
+            mode: "cors"
+        };
+
+        if (method === "POST") requestInfo.body = data + ((data.length > 0) ? "&" : "") + "authenticity_token=" + this.authToken;
+
+        const entry = new Request(location.origin + "/" + path + ((query.length > 0) ? "?" : "") + query, requestInfo);
+        const index = this.requestIndex++;
+        const final = new Promise<any>((resolve) => {
+            $(document).on("api.re621.result-" + index, (event, data) => {
+                $(document).off("api.re621.result-" + index);
+                resolve(data);
+            });
+        });
+
+        this.queue.push({ request: entry, index: index, delay: delay });
+        this.run();
+
+        return final;
+    }
+
+    /** Starts the queue processing, if it has not happened already */
+    private async run(): Promise<void> {
+        if (this.processing) return;
+        this.processing = true;
+
+        while (this.queue.length > 0) {
+            const item = this.queue.shift();
+            const data = await fetch(item.request);
+            $(document).trigger("api.re621.result-" + item.index, await data.json());
+            await new Promise((resolve) => { setTimeout(() => { resolve(); }, item.delay) });
+        }
+    }
+}
+
+interface EndpointDefinition {
+    /**
+     * **name** - irrelevant, as long as it's unique  
+     * ex. posts, forum_posts, comments, etc
+     */
+    name: string;
+
+    /**
+     * **path** - endpoint path, without origin or extension  
+     * ex. posts, forum_posts, comments, etc.
+     */
+    path: string;
+}
+
+type APIQuery = {
+    [prop: string]: string | string[];
+};
+
+interface QueueItem {
+    request: Request;
+    index: number;
+    delay: number;
+}

--- a/src/js/components/api/E621.ts
+++ b/src/js/components/api/E621.ts
@@ -49,7 +49,7 @@ class APIEndpoint {
      * @param query Request query, either as a raw string or an APIQuery
      * @param delay Optional delay override, in milliseconds
      */
-    public async get(query: string | APIQuery, delay?: number): Promise<any> {
+    public async get(query?: string | APIQuery, delay?: number): Promise<any> {
         return this.queue.createRequest(this.getParsedPath(), this.queryToString(query), "GET", "", delay);
     }
 
@@ -58,7 +58,7 @@ class APIEndpoint {
      * @param data Data to be sent with the request
      * @param delay Optional delay override, in milliseconds
      */
-    public async post(data: {}, delay?: number): Promise<any> {
+    public async post(data?: string | APIQuery, delay?: number): Promise<any> {
         return this.queue.createRequest(this.getParsedPath(), "", "POST", this.queryToString(data), delay);
     }
 
@@ -72,6 +72,7 @@ class APIEndpoint {
 
     /** Converts APIQuery into a raw string */
     private queryToString(query: string | APIQuery): string {
+        if (query === undefined) return "";
         if (typeof query === "string") return query;
 
         const keys = Object.keys(query);

--- a/src/js/components/api/PostHtml.ts
+++ b/src/js/components/api/PostHtml.ts
@@ -1,8 +1,8 @@
-import { ApiPost } from "./responses/ApiPost";
+import { APIPost } from "./responses/APIPost";
 
 export class PostHtml {
 
-    public static create(json: ApiPost): JQuery<HTMLElement> {
+    public static create(json: APIPost): JQuery<HTMLElement> {
         //data-has-sound
         //data-flags
         const tags = json.tags;
@@ -75,7 +75,7 @@ export class PostHtml {
         return $article;
     }
 
-    private static getScoreInfo(json: ApiPost): ScoreInfo {
+    private static getScoreInfo(json: APIPost): ScoreInfo {
         if (json.score.total === 0) {
             return {
                 class: "score-neutral",
@@ -94,7 +94,7 @@ export class PostHtml {
         }
     }
 
-    private static getArticleClasses(json: ApiPost): string[] {
+    private static getArticleClasses(json: APIPost): string[] {
         const result = [
             "blacklisted",
             "captioned",
@@ -125,7 +125,7 @@ export class PostHtml {
         return result;
     }
 
-    private static getFlags(json: ApiPost): string[] {
+    private static getFlags(json: APIPost): string[] {
         const result = [];
         if (json.flags.deleted) {
             result.push("deleted");
@@ -137,7 +137,7 @@ export class PostHtml {
         return result;
     }
 
-    private static getExtra(json: ApiPost): string {
+    private static getExtra(json: APIPost): string {
         let result = "";
         if (json.relationships.parent_id !== null) {
             result += "P";

--- a/src/js/components/api/responses/APIBlip.ts
+++ b/src/js/components/api/responses/APIBlip.ts
@@ -1,0 +1,10 @@
+export interface APIBlip extends APIResponse {
+    id: number;
+    creator_id: number;
+    body: string;
+    response_to: number;
+    created_at: string;
+    updated_at: string;
+    is_hidden: boolean;
+    creator_name: string;
+}

--- a/src/js/components/api/responses/APIComment.ts
+++ b/src/js/components/api/responses/APIComment.ts
@@ -1,4 +1,4 @@
-export interface ApiComment {
+export interface APIComment extends APIResponse {
     id: number;
     created_at: string;
     post_id: number;

--- a/src/js/components/api/responses/APIFavorite.ts
+++ b/src/js/components/api/responses/APIFavorite.ts
@@ -1,0 +1,7 @@
+import { APIPost } from "./APIPost";
+
+export interface APIFavorite extends APIPost {
+    // The favorites endpoint uses the same format as the posts
+    // If this changes, this interface will need to be updated.
+    id: number;
+}

--- a/src/js/components/api/responses/APIForumPost.ts
+++ b/src/js/components/api/responses/APIForumPost.ts
@@ -1,0 +1,10 @@
+export interface APIForumPost extends APIResponse {
+    id: number;
+    created_at: string;
+    updated_at: string;
+    body: string;
+    creator_id: number;
+    updater_id: number;
+    topic_id: number;
+    is_hidden: boolean;
+}

--- a/src/js/components/api/responses/APIForumTopic.ts
+++ b/src/js/components/api/responses/APIForumTopic.ts
@@ -1,4 +1,4 @@
-export interface ApiForumTopic {
+export interface APIForumTopic extends APIResponse {
     id: number;
     creator_id: number;
     updater_id: number;
@@ -10,15 +10,4 @@ export interface ApiForumTopic {
     created_at: string;
     updated_at: string;
     category_id: number;
-}
-
-export interface ApiForumPost {
-    id: number;
-    created_at: string;
-    updated_at: string;
-    body: string;
-    creator_id: number;
-    updater_id: number;
-    topic_id: number;
-    is_hidden: boolean;
 }

--- a/src/js/components/api/responses/APINote.ts
+++ b/src/js/components/api/responses/APINote.ts
@@ -1,0 +1,15 @@
+export interface APINote extends APIResponse {
+    id: number;
+    created_at: string;
+    updated_at: string;
+    creator_id: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    version: number;
+    is_active: boolean;
+    post_id: number;
+    body: string;
+    creator_name: string;
+}

--- a/src/js/components/api/responses/APIResponse.ts
+++ b/src/js/components/api/responses/APIResponse.ts
@@ -1,4 +1,7 @@
-
+/**
+ * Generic response from the e621 API.  
+ * Other responses should extend this for proper typecasting.  
+ */
 interface APIResponse {
     id: number;
     error: string;

--- a/src/js/components/api/responses/APIResponse.ts
+++ b/src/js/components/api/responses/APIResponse.ts
@@ -1,0 +1,5 @@
+
+interface APIResponse {
+    id: number;
+    error: string;
+}

--- a/src/js/components/api/responses/APISet.ts
+++ b/src/js/components/api/responses/APISet.ts
@@ -1,0 +1,13 @@
+export interface APISet extends APIResponse {
+    id: number;
+    created_at: string;
+    updated_at: string;
+    creator_id: number;
+    is_public: boolean;
+    name: string;
+    shortname: string;
+    description: string;
+    post_count: number;
+    transfer_on_delete: boolean;
+    post_ids: number[];
+}

--- a/src/js/components/api/responses/APITagAlias.ts
+++ b/src/js/components/api/responses/APITagAlias.ts
@@ -1,0 +1,14 @@
+export interface APITagAlias extends APIResponse {
+    id: number;
+    antecedent_name: string;
+    consequent_name: string;
+    reason: string;
+    creator_id: number;
+    created_at: string;
+    updated_at: string;
+    forum_post_id: number;
+    forum_topic_id: number;
+    status: string;
+    post_count: number;
+    approver_id: number;
+}

--- a/src/js/components/api/responses/APITagImplication.ts
+++ b/src/js/components/api/responses/APITagImplication.ts
@@ -1,0 +1,7 @@
+import { APITagAlias } from "./APITagAlias";
+
+export interface APITagImplication extends APITagAlias {
+    // Both aliases and implications use the same format.
+    // If this changes, this interface will need to be updated.
+    id: number;
+}

--- a/src/js/components/api/responses/APIUser.ts
+++ b/src/js/components/api/responses/APIUser.ts
@@ -1,4 +1,20 @@
-export interface ApiUserSettings {
+export interface APIUser extends APIResponse {
+    id: number;
+    created_at: string;
+    name: string;
+    level: number;
+    base_upload_limit: number;
+    post_upload_count: number;
+    post_update_count: number;
+    note_update_count: number;
+    is_banned: boolean;
+    can_approve_posts: boolean;
+    can_upload_free: boolean;
+    level_string: string;
+}
+
+export interface APICurrentUser extends APIUser {
+    id: number;
     wiki_page_version_count: number;
     artist_version_count: number;
     pool_version_count: number;
@@ -10,18 +26,6 @@ export interface ApiUserSettings {
     neutral_feedback_count: number;
     negative_feedback_count: number;
     upload_limit: number;
-    id: number;
-    created_at: Date;
-    name: string;
-    level: number;
-    base_upload_limit: number;
-    post_upload_count: number;
-    post_update_count: number;
-    note_update_count: number;
-    is_banned: boolean;
-    can_approve_posts: boolean;
-    can_upload_free: boolean;
-    level_string: string;
     show_avatars: boolean;
     blacklist_avatars: boolean;
     blacklist_users: boolean;

--- a/src/js/components/api/responses/ApiPool.ts
+++ b/src/js/components/api/responses/ApiPool.ts
@@ -1,4 +1,4 @@
-export interface ApiPool {
+export interface APIPool extends APIResponse {
     id: number;
     name: string;
     created_at: string;

--- a/src/js/components/api/responses/ApiPost.ts
+++ b/src/js/components/api/responses/ApiPost.ts
@@ -1,4 +1,4 @@
-export interface ApiPost extends APIResponse {
+export interface APIPost extends APIResponse {
     id: number;
     created_at: string;
     updated_at: string;

--- a/src/js/components/api/responses/ApiPost.ts
+++ b/src/js/components/api/responses/ApiPost.ts
@@ -1,4 +1,4 @@
-export interface ApiPost {
+export interface ApiPost extends APIResponse {
     id: number;
     created_at: string;
     updated_at: string;

--- a/src/js/components/api/responses/ApiTag.ts
+++ b/src/js/components/api/responses/ApiTag.ts
@@ -1,4 +1,4 @@
-export interface ApiTag {
+export interface APITag extends APIResponse {
     id: number;
     name: string;
     post_count: number;

--- a/src/js/components/api/responses/ApiWikiPage.ts
+++ b/src/js/components/api/responses/ApiWikiPage.ts
@@ -1,4 +1,4 @@
-export interface ApiWikiPage {
+export interface APIWikiPage extends APIResponse {
     id: number;
     created_at: Date;
     updated_at: Date;

--- a/src/js/components/data/User.ts
+++ b/src/js/components/data/User.ts
@@ -1,7 +1,7 @@
 import { Api } from "../api/Api";
 import { PostFilter } from "./PostFilter";
 import { Post } from "./Post";
-import { ApiUserSettings } from "../api/responses/ApiUserSettings";
+import { APICurrentUser } from "../api/responses/APIUser";
 
 /**
  * User  
@@ -100,7 +100,7 @@ export class User {
     /**
      * @returns the users e6 site settings
      */
-    public static async getCurrentSettings(): Promise<ApiUserSettings> {
+    public static async getCurrentSettings(): Promise<APICurrentUser> {
         return Api.getJson("/users/" + this.getUserID() + ".json");
     }
 

--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -1,7 +1,7 @@
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Page, PageDefintion } from "../../components/data/Page";
 import { Api } from "../../components/api/Api";
-import { ApiForumPost } from "../../components/api/responses/ApiForum";
+import { APIForumPost } from "../../components/api/responses/APIForumPost";
 
 /**
  * Miscellaneous functionality that does not require a separate module
@@ -172,7 +172,7 @@ export class Miscellaneous extends RE6Module {
         const selection = window.getSelection().toString();
 
         if (selection === "") {
-            const jsonData: ApiForumPost = await Api.getJson(requestURL);
+            const jsonData: APIForumPost = await Api.getJson(requestURL);
             strippedBody = jsonData.body.replace(/\[quote\](?:.|\n|\r)+?\[\/quote\][\n\r]*/gm, "");
             strippedBody = `[quote]"` + $parent.data('creator') + `":/user/show/` + $parent.data('creator-id') + ` said:\n` + strippedBody + `\n[/quote]`;
         } else {

--- a/src/js/modules/misc/TinyAlias.ts
+++ b/src/js/modules/misc/TinyAlias.ts
@@ -1,10 +1,10 @@
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { PageDefintion } from "../../components/data/Page";
 import { Api } from "../../components/api/Api";
-import { ApiTag } from "../../components/api/responses/ApiTag";
+import { APITag } from "../../components/api/responses/APITag";
 import { Modal } from "../../components/structure/Modal";
 import { AvoidPosting } from "../../components/data/AvoidPosting";
-import { ApiWikiPage } from "../../components/api/responses/ApiWikiPage";
+import { APIWikiPage } from "../../components/api/responses/APIWikiPage";
 
 export class TinyAlias extends RE6Module {
 
@@ -300,7 +300,7 @@ export class TinyAlias extends RE6Module {
         };
 
         // First data query
-        let jsonData: ApiTag = await Api.getJson("/tags/" + tag + ".json", 500);
+        let jsonData: APITag = await Api.getJson("/tags/" + tag + ".json", 500);
         if (jsonData === null) {
             result.isInvalid = true;
             return result;
@@ -311,7 +311,7 @@ export class TinyAlias extends RE6Module {
         this.$infoText.html(result.count + " posts");
 
         // Checking for aliases
-        const aliasJson: ApiTag = await Api.getJson("/tag_aliases.json?search[antecedent_name]=" + tag, 500);
+        const aliasJson: APITag = await Api.getJson("/tag_aliases.json?search[antecedent_name]=" + tag, 500);
         if (aliasJson[0] !== undefined) {
             result.isAliased = true;
             const trueTagName = aliasJson[0].consequent_name;
@@ -327,7 +327,7 @@ export class TinyAlias extends RE6Module {
             result.isDNP = true;
         }
 
-        const wikiPage: ApiWikiPage = (await Api.getJson(`/wiki_pages.json?search[title]=${encodeURIComponent(result.realName)}`, 500))[0];
+        const wikiPage: APIWikiPage = (await Api.getJson(`/wiki_pages.json?search[title]=${encodeURIComponent(result.realName)}`, 500))[0];
         if (wikiPage !== undefined && wikiPage.title === result.realName) {
             result.wikiPageId = wikiPage.id;
         }

--- a/src/js/modules/search/InfiniteScroll.ts
+++ b/src/js/modules/search/InfiniteScroll.ts
@@ -1,7 +1,7 @@
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Page, PageDefintion } from "../../components/data/Page";
 import { Api } from "../../components/api/Api";
-import { ApiPost } from "../../components/api/responses/ApiPost";
+import { APIPost } from "../../components/api/responses/APIPost";
 import { PostHtml } from "../../components/api/PostHtml";
 import { InstantSearch } from "./InstantSearch";
 import { Post } from "../../components/data/Post";
@@ -85,7 +85,7 @@ export class InfiniteScroll extends RE6Module {
         }
         this.isInProgress = true;
         this.$loadingIndicator.show();
-        const posts: ApiPost[] = (await Api.getJson(`/posts.json?tags=${this.currentQuery}&page=${this.nextPageToGet}`)).posts;
+        const posts: APIPost[] = (await Api.getJson(`/posts.json?tags=${this.currentQuery}&page=${this.nextPageToGet}`)).posts;
         if (posts.length === 0) {
             this.pagesLeft = false;
             this.$loadingIndicator.hide();

--- a/src/js/modules/subscriptions/ForumSubscriptions.ts
+++ b/src/js/modules/subscriptions/ForumSubscriptions.ts
@@ -3,7 +3,7 @@ import { Api } from "../../components/api/Api";
 import { Page, PageDefintion } from "../../components/data/Page";
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Subscription } from "./Subscription";
-import { ApiForumTopic } from "../../components/api/responses/ApiForum";
+import { APIForumTopic } from "../../components/api/responses/APIForumTopic";
 import { User } from "../../components/data/User";
 
 export class ForumSubscriptions extends RE6Module implements Subscription {
@@ -67,7 +67,7 @@ export class ForumSubscriptions extends RE6Module implements Subscription {
             return results;
         }
 
-        const forumsJson: ApiForumTopic[] = await Api.getJson("/forum_topics.json?search[id]=" + Object.keys(forumData).join(","));
+        const forumsJson: APIForumTopic[] = await Api.getJson("/forum_topics.json?search[id]=" + Object.keys(forumData).join(","));
         for (const forumJson of forumsJson) {
             if (new Date(forumJson.updated_at).getTime() > lastUpdate && forumJson.updater_id !== User.getUserID()) {
                 results[new Date(forumJson.updated_at).getTime()] = await this.formatForumUpdate(forumJson);
@@ -77,7 +77,7 @@ export class ForumSubscriptions extends RE6Module implements Subscription {
         return results;
     }
 
-    private async formatForumUpdate(value: ApiForumTopic): Promise<UpdateContent> {
+    private async formatForumUpdate(value: APIForumTopic): Promise<UpdateContent> {
         return {
             id: value.id,
             name: value.title,

--- a/src/js/modules/subscriptions/PoolSubscriptions.ts
+++ b/src/js/modules/subscriptions/PoolSubscriptions.ts
@@ -1,10 +1,10 @@
 import { UpdateData, UpdateDefinition, SubscriptionSettings, UpdateContent } from "./SubscriptionManager";
-import { ApiPool } from "../../components/api/responses/ApiPool";
+import { APIPool } from "../../components/api/responses/APIPool";
 import { Api } from "../../components/api/Api";
 import { Page } from "../../components/data/Page";
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Subscription } from "./Subscription";
-import { ApiPost } from "../../components/api/responses/ApiPost";
+import { APIPost } from "../../components/api/responses/APIPost";
 import { Post } from "../../components/data/Post";
 
 export class PoolSubscriptions extends RE6Module implements Subscription {
@@ -69,7 +69,7 @@ export class PoolSubscriptions extends RE6Module implements Subscription {
             return results;
         }
 
-        const poolsJson: ApiPool[] = await Api.getJson("/pools.json?search[id]=" + Object.keys(poolData).join(","));
+        const poolsJson: APIPool[] = await Api.getJson("/pools.json?search[id]=" + Object.keys(poolData).join(","));
         for (const poolJson of poolsJson) {
             if (poolData[poolJson.id].lastId === undefined || !poolJson.post_ids.includes(poolData[poolJson.id].lastId)) {
                 poolData[poolJson.id].lastId = poolJson.post_ids[poolJson.post_ids.length - 1];
@@ -86,10 +86,10 @@ export class PoolSubscriptions extends RE6Module implements Subscription {
         return results;
     }
 
-    private async formatPoolUpdate(value: ApiPool, subSettings: SubscriptionSettings): Promise<UpdateContent> {
+    private async formatPoolUpdate(value: APIPool, subSettings: SubscriptionSettings): Promise<UpdateContent> {
         const poolInfo = subSettings[value.id];
         if (poolInfo.md5 === undefined) {
-            const post: ApiPost = (await Api.getJson(`/posts/${value.post_ids[0]}.json`)).post;
+            const post: APIPost = (await Api.getJson(`/posts/${value.post_ids[0]}.json`)).post;
             poolInfo.md5 = post.file.ext === "swf" ? "" : post.file.md5;
         }
         return {

--- a/src/js/modules/subscriptions/TagSubscriptions.ts
+++ b/src/js/modules/subscriptions/TagSubscriptions.ts
@@ -2,7 +2,7 @@ import { UpdateData, UpdateDefinition, SubscriptionSettings, UpdateContent } fro
 import { Api } from "../../components/api/Api";
 import { RE6Module, Settings } from "../../components/RE6Module";
 import { Subscription } from "./Subscription";
-import { ApiPost } from "../../components/api/responses/ApiPost";
+import { APIPost } from "../../components/api/responses/APIPost";
 import { Post } from "../../components/data/Post";
 
 export class TagSubscriptions extends RE6Module implements Subscription {
@@ -72,7 +72,7 @@ export class TagSubscriptions extends RE6Module implements Subscription {
         }
 
         for (const tagName of Object.keys(tagData)) {
-            const postsJson: ApiPost[] = (await Api.getJson("/posts.json?tags=" + encodeURIComponent(tagName.replace(/ /g, "_")))).posts;
+            const postsJson: APIPost[] = (await Api.getJson("/posts.json?tags=" + encodeURIComponent(tagName.replace(/ /g, "_")))).posts;
             for (const post of postsJson) {
                 if (new Date(post.created_at).getTime() > lastUpdate) {
                     results[new Date(post.created_at).getTime()] = await this.formatPostUpdate(post, tagName);
@@ -83,7 +83,7 @@ export class TagSubscriptions extends RE6Module implements Subscription {
         return results;
     }
 
-    private async formatPostUpdate(value: ApiPost, tagName: string): Promise<UpdateContent> {
+    private async formatPostUpdate(value: APIPost, tagName: string): Promise<UpdateContent> {
         return {
             id: value.id,
             name: tagName.replace(/ /g, " "),


### PR DESCRIPTION
I have been somewhat dissatisfied with the current API solution.
It works just fine, but the idea of having to write out the whole endpoint URL every single time does not sit well with me. So, I created a little wrapper for those.

Usage:
``````
E621.Posts.get({"tags": ["horse", "male", solo"]});    // GET request to /posts.json?tags=horse+male+solo
E621.Users.find("12345").get();                        // GET request to /users/12345.json
E621.ForumTopics.get({"search[id]", "98765"});         // GET request to  /forum_topics.json?search[id]=98765

E621.Users.spec("12345").post({"somesetting": "off"}); // POST request to /users/12345.json
``````

Let me know what you think.