### PR TITLE
Add padding to pool downloads to fix sorting in some situations (Imgur galleries)

### DIFF
--- a/src/js/modules/downloader/PoolDownloader.ts
+++ b/src/js/modules/downloader/PoolDownloader.ts
@@ -332,12 +332,26 @@ export class PoolDownloader extends RE6Module {
     private createFilename(post: PostData, downloadSamples = false): string {
         return MassDownloader.createFilenameBase(this.fetchSettings<string>("template"), post)
             .replace(/%pool%/g, this.poolName)
-            .replace(/%index%/g, "" + (this.poolFiles.indexOf(post.id) + 1))
+            .replace(/%index%/g, this.padIndex(this.poolFiles.indexOf(post.id) + 1, this.poolFiles.length.toString().length))
             .slice(0, 128)
             .replace(/-{2,}/g, "-")
             .replace(/-*$/g, "")
             + "."
             + ((downloadSamples && post.has.sample) ? "jpg" : post.file.ext);
+    }
+
+    /**
+     * Pads the index to make the files sort better
+     * @param index The index to be padded
+     * @param length The padding amount, the amount of digits in pool length. Defaults to 2
+     */
+    private padIndex(index: number, length = 2): string {
+        let str = index.toString();
+        while (str.length < length) {
+            str = "0" + str;
+        }
+
+        return str;
     }
 
     /**


### PR DESCRIPTION
I noticed an issue when attempting to upload a comic downloaded with re621 to imgur. The order of the pages were wrong. This stems from imgur sorting 11 before 2. So if a comic was more than 10 pages it would lead to Page 1 > Page 11 > Page 2, etc.

This pull request fixes that issue by padding it with zeroes in front so that 1 becomes 01. Uploading to imgur with this configuration fixes the out of order pages. 
The function accounts for total page count, so comics with 10+, 100+ and even 1000 is supported, and only adds the necessary padding, or none if page count is under 10.