### PR TITLE
Fixed SmartAlias and EditTracker not being run when using secondary side edit link/button

### DIFF
--- a/src/js/modules/downloader/MassDownloader.ts
+++ b/src/js/modules/downloader/MassDownloader.ts
@@ -353,7 +353,7 @@ export class MassDownloader extends RE6Module {
             .replace(/%md5%/g, post.file.md5);
 
         function tagSetToString(tags: Set<string>): string {
-            return [...tags].join("-").replace(/\||\*|\/|\\|:|"/, "_");
+            return [...tags].join("-").replace(/\||\*|\/|\\|:|"/g, "_");
         }
     }
 

--- a/src/js/modules/downloader/PoolDownloader.ts
+++ b/src/js/modules/downloader/PoolDownloader.ts
@@ -332,12 +332,26 @@ export class PoolDownloader extends RE6Module {
     private createFilename(post: PostData, downloadSamples = false): string {
         return MassDownloader.createFilenameBase(this.fetchSettings<string>("template"), post)
             .replace(/%pool%/g, this.poolName)
-            .replace(/%index%/g, "" + (this.poolFiles.indexOf(post.id) + 1))
+            .replace(/%index%/g, this.padIndex(this.poolFiles.indexOf(post.id) + 1, this.poolFiles.length.toString().length))
             .slice(0, 128)
             .replace(/-{2,}/g, "-")
             .replace(/-*$/g, "")
             + "."
             + ((downloadSamples && post.has.sample) ? "jpg" : post.file.ext);
+    }
+
+    /**
+     * Pads the index to make the files sort better
+     * @param index The index to be padded
+     * @param length The padding amount, the amount of digits in pool length. Defaults to 2
+     */
+    private padIndex(index: number, length = 2): string {
+        let str = index.toString();
+        while (str.length < length) {
+            str = "0" + str;
+        }
+
+        return str;
     }
 
     /**

--- a/src/js/modules/general/JanitorEnhancements.ts
+++ b/src/js/modules/general/JanitorEnhancements.ts
@@ -68,7 +68,7 @@ export class JanitorEnhancements extends RE6Module {
         for (const reason of this.deletionReasons) {
             if (reason == "") $("<br />").appendTo(suggestionsWrapper);
             else $("<a>")
-                .html(reason.replace(/%PARENT_ID%/g, parentID))
+                .text(reason.replace(/%PARENT_ID%/g, parentID))
                 .appendTo(suggestionsWrapper)
                 .on("click", (event) => {
                     event.preventDefault();

--- a/src/js/modules/misc/EditTracker.ts
+++ b/src/js/modules/misc/EditTracker.ts
@@ -11,7 +11,7 @@ export class EditTracker extends RE6Module {
     public create(): void {
 
         if ($("#post_tag_string").is(":visible")) this.listen();
-        else $("body").one("click.re621", "#post-edit-link", () => { this.listen(); });
+        else {$("body").one("click.re621", "#post-edit-link, #side-edit-link", () => { this.listen(); });}
     }
 
     private async listen(): Promise<void> {

--- a/src/js/modules/misc/SmartAlias.ts
+++ b/src/js/modules/misc/SmartAlias.ts
@@ -84,7 +84,7 @@ export class SmartAlias extends RE6Module {
             // This fixes an issue with SmartAlias not loading if the editing form is opened before page loads
 
             SmartAlias.postPageLockout = true;
-            $("body").one("click.re621", "#post-edit-link", () => {
+            $("body").one("click.re621", "#post-edit-link, #side-edit-link", () => {
                 SmartAlias.postPageLockout = false;
                 this.reload();
             });

--- a/src/js/modules/post/DownloadCustomizer.ts
+++ b/src/js/modules/post/DownloadCustomizer.ts
@@ -133,7 +133,7 @@ export class DownloadCustomizer extends RE6Module {
             + "." + (ext ? ext : post.file.ext);
 
         function tagSetToString(tags: Set<string>): string {
-            return [...tags].join("-").replace(/\||\*|\/|\\|:|"/, "_");
+            return [...tags].join("-").replace(/\||\*|\/|\\|:|"/g, "_");
         }
     }
 


### PR DESCRIPTION
Currently, the edit link on the left side (under the tags) doesn't start SmartAlias and EditTracker due to it only listening to a click event on the main edit link.

This fixes that by just adding `#side-edit-link` as a selector to the handler attach function.