### PR TITLE
Fix some files in `build` folder getting linted

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,7 @@
         },
         {
             "files": [
-                "build/*.js",
+                "build/**/*.js",
                 "bin/*.js"
             ],
             "rules": {


### PR DESCRIPTION
Just a small edit to fix eslint attempting to lint the built userscript (`script.user.js`), causing thousands of errors/problems in VS Code.