### PR TITLE
Add Copy ID button to forum posts and comments

### DIFF
--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -61,9 +61,10 @@ export class Miscellaneous extends RE6Module {
     public create(): void {
         super.create();
 
-        // Enhanced quoting button
+        // Enhanced quoting button and copy ID button
         if (Page.matches([PageDefinition.post, PageDefinition.forum])) {
             this.handleQuoteButton();
+            this.handleIDButton();
         }
 
         // Sticky elements
@@ -260,6 +261,39 @@ export class Miscellaneous extends RE6Module {
                 event.preventDefault();
                 const $parent = $(event.target).parents("article.comment");
                 this.quote($parent, "comment", $parent.data("comment-id"), $("#comment_body_for_"), $("a.expand-comment-response"));
+            });
+        }
+    }
+
+    /**
+     * Generates the "Copy ID" button on comments and forum posts 
+     */
+    private handleIDButton(): void {
+        if (Page.matches(PageDefinition.forum)) {
+            $(".content-menu > menu").each(function (index, element) {
+                const $copyElement = $("<a>")
+                    .addClass("re621-forum-post-copy-id")
+                    .html("Copy ID");
+                $(element).append($copyElement.wrap("<li>"));
+            });
+
+            $(".re621-forum-post-copy-id").on('click', (event) => {
+                event.preventDefault();
+                const $post = $(event.target).parents("article.forum-post");
+                XM.Util.setClipboard($post.data("forum-post-id"));
+            });
+        } else if (Page.matches(PageDefinition.post)) {
+            $(".content-menu > menu").each(function (index, element) {
+                const $copyElement = $("<a>")
+                    .addClass("re621-comment-copy-id")
+                    .html("Copy ID");
+                $(element).append($copyElement.wrap("<li>"));
+            });
+
+            $(".re621-comment-copy-id").on('click', (event) => {
+                event.preventDefault();
+                const $comment = $(event.target).parents("article.comment");
+                XM.Util.setClipboard($comment.data("comment-id"));
             });
         }
     }

--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -270,8 +270,8 @@ export class Miscellaneous extends RE6Module {
      */
     private handleIDButton(): void {
         if (Page.matches(PageDefinition.forum)) {
-            // Using li:last to put the button before the vote menu
-            $(".content-menu > menu > li:last").each(function (index, element) {
+            // Using li:last-of-type to put the button before the vote menu
+            $(".content-menu > menu > li:last-of-type").each(function (index, element) {
                 const $copyElement = $("<a>")
                     .addClass("re621-forum-post-copy-id")
                     .html("Copy ID");

--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -270,11 +270,13 @@ export class Miscellaneous extends RE6Module {
      */
     private handleIDButton(): void {
         if (Page.matches(PageDefinition.forum)) {
-            $(".content-menu > menu").each(function (index, element) {
+            // Using li:last to put the button before the vote menu
+            $(".content-menu > menu > li:last").each(function (index, element) {
                 const $copyElement = $("<a>")
                     .addClass("re621-forum-post-copy-id")
                     .html("Copy ID");
-                $(element).append($copyElement.wrap("<li>"));
+                $(element).after($copyElement);
+                $($copyElement).wrap("<li>");
             });
 
             $(".re621-forum-post-copy-id").on('click', (event) => {
@@ -287,7 +289,8 @@ export class Miscellaneous extends RE6Module {
                 const $copyElement = $("<a>")
                     .addClass("re621-comment-copy-id")
                     .html("Copy ID");
-                $(element).append($copyElement.wrap("<li>"));
+                $(element).append($copyElement);
+                $($copyElement).wrap("<li>");
             });
 
             $(".re621-comment-copy-id").on('click', (event) => {


### PR DESCRIPTION
While reporting a user and needing to refer to multiple comments I noticed that there was no easy way of getting the comment ID, so I thought it could be a nice feature to add to re621.