### PR TITLE
Replace fs.rmdirSync with fs.rmSync

### DIFF
--- a/bin/cleanup.js
+++ b/bin/cleanup.js
@@ -1,4 +1,3 @@
 const fs = require("fs");
 
-if (fs.existsSync("./build/tsc-temp"))
-    fs.rmdirSync("./build/tsc-temp/", { recursive: true });
+fs.rmSync("./build/tsc-temp", { recursive: true, force: true });

--- a/bin/extension.js
+++ b/bin/extension.js
@@ -6,13 +6,10 @@ const fs = require("fs"),
 const prodMode = process.argv[2] === "prod";
 
 // Prepare the directory
-if (fs.existsSync("./build/extension"))
-    fs.rmdirSync("./build/extension", { recursive: true });
-fs.mkdirSync("./build/extension");
-fs.mkdirSync("./build/extension/src");
-fs.mkdirSync("./build/extension/src/lib");
+fs.rmSync("./build/extension", { recursive: true, force: true });
+fs.mkdirSync("./build/extension/src/lib",  { recursive: true });
 
-if (prodMode && fs.existsSync("./build/cache")) fs.rmdirSync("./build/cache", { recursive: true });
+if (prodMode) fs.rmSync("./build/cache", { recursive: true, force: true });
 if (!fs.existsSync("./build/cache")) fs.mkdirSync("./build/cache");
 
 const manifest = JSON.parse(util.parseTemplate(

--- a/bin/userscript.js
+++ b/bin/userscript.js
@@ -8,8 +8,7 @@ const headerData = JSON.parse(fs.readFileSync("./bin/userscript-header.json")),
 
 // Prepare the directory
 if (mode !== "injector") {
-    if (fs.existsSync("./build/userscript"))
-        fs.rmdirSync("./build/userscript", { recursive: true });
+    fs.rmSync("./build/userscript", { recursive: true, force: true });
     fs.mkdirSync("./build/userscript");
 }
 


### PR DESCRIPTION
This was soft deprecated in v14.14 and shows a warning since v16.
The build actions are run with v14.17, should be fine.