### PR TITLE
Fix "learn how to comment guide" not getting hidden

### DIFF
--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -95,7 +95,7 @@ export class Miscellaneous extends RE6Module {
         this.handleAvatarClick(this.fetchSettings("avatarClick"));
 
         // How to comment guide
-        this.handleCommentRules(this.fetchSettings("disableCommentRules"));
+        $(() => { this.handleCommentRules(this.fetchSettings("disableCommentRules")); });
 
         // Fix the forum title
         if (this.fetchSettings("fixForumTitle") && Page.matches(PageDefinition.forum)) {


### PR DESCRIPTION
This fixes a bug that was before only persistent for WebMs (or at least that's how I noticed it), however while working on another feature I noticed it now happened with regular images as well. 
I managed to narrow it down to either it being a WebM, or the post having a description (haven't tested if length matters but still). In those cases, the code was too quick, and attempted to find the element that didn't exist yet.

This PR fixes that super easily by simply waiting for the document to finish loading so it's able to find the element properly regardless of if a description exists, or the post is a WebM.