### PR TITLE
Replace deprecated methods

### DIFF
--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -22,13 +22,7 @@ const sRespFn = {
                 });
             },
             "setClipboard": (data): void => {
-                const copyFrom = document.createElement("textarea");
-                copyFrom.textContent = data;
-                document.body.appendChild(copyFrom);
-                copyFrom.select();
-                document.execCommand("copy");
-                copyFrom.blur();
-                document.body.removeChild(copyFrom);
+                navigator.clipboard.writeText(data);
             }
         },
     },

--- a/src/js/components/data/Blacklist.ts
+++ b/src/js/components/data/Blacklist.ts
@@ -192,7 +192,7 @@ export class Blacklist {
         return Promise.resolve();
 
         function getTagLink(tagName: string): string {
-            if (tagName.startsWith("id:")) return `<a href="/posts/${tagName.substr(3)}" target="_blank" rel="noopener noreferrer">${tagName}</a>`;
+            if (tagName.startsWith("id:")) return `<a href="/posts/${tagName.substring(3)}" target="_blank" rel="noopener noreferrer">${tagName}</a>`;
             return `<a href="/wiki_pages/show_or_new?title=${tagName}">${tagName}</a>`;
         }
     }

--- a/src/js/components/post/Post.ts
+++ b/src/js/components/post/Post.ts
@@ -583,7 +583,7 @@ export namespace PostData {
 
         // Restore the preview image. Not used anywhere, but avoids an error.
         const md5 = data["file"]["md5"],
-            md52 = md5.substr(0, 2);
+            md52 = md5.substring(0, 2);
         data["preview"] = {
             "width": -1,
             "height": -1,
@@ -649,7 +649,7 @@ export namespace PostData {
         if ($article.hasClass("post-preview")) {
             if ($article.attr("data-md5")) md5 = $article.attr("data-md5");
             else if ($article.attr("data-file-url"))
-                md5 = $article.attr("data-file-url").substr(36, 32);
+                md5 = $article.attr("data-file-url").substring(36, 68);
 
             urls = {
                 preview: $article.attr("data-preview-file-url") || null,
@@ -659,7 +659,7 @@ export namespace PostData {
         } else {
             if ($article.attr("data-md5")) md5 = $article.attr("data-md5");
             else if ($article.attr("data-preview-url"))
-                md5 = $article.attr("data-preview-url").substr(44, 32);
+                md5 = $article.attr("data-preview-url").substring(44, 72);
 
             if (md5 == undefined) urls = {
                 preview: `/images/deleted-preview.png`,
@@ -670,13 +670,13 @@ export namespace PostData {
                 urls = {
                     preview: $article.attr("data-preview-url")
                         ? $article.attr("data-preview-url")
-                        : `https://static1.e621.net/data/preview/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`,
+                        : `https://static1.e621.net/data/preview/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`,
                     sample: $article.attr("data-large-file-url")    // This is horrifying.
                         ? $article.attr("data-large-file-url")      // I am truly sorry...
                         : ((width < 850 || height < 850 || extension == "gif")
-                            ? `https://static1.e621.net/data/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.${extension}`
-                            : `https://static1.e621.net/data/sample/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`),
-                    original: `https://static1.e621.net/data/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.${extension}`,
+                            ? `https://static1.e621.net/data/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.${extension}`
+                            : `https://static1.e621.net/data/sample/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`),
+                    original: `https://static1.e621.net/data/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.${extension}`,
                 };
             }
         }

--- a/src/js/components/utility/UtilEvents.ts
+++ b/src/js/components/utility/UtilEvents.ts
@@ -48,8 +48,7 @@ export class UtilEvents {
      * @param label Data attribute to set on the element
      */
     public static triggerVueEvent(element: JQuery<HTMLElement>, name: string, label?: string): void {
-        const e = document.createEvent('HTMLEvents');
-        e.initEvent(name, true, true);
+        const e = new Event(name, { "bubbles": true, "cancelable": true });
         if (label) element.data(label, "true");
         element[0].dispatchEvent(e);
     }

--- a/src/js/modules/general/CommentBlacklist.ts
+++ b/src/js/modules/general/CommentBlacklist.ts
@@ -49,7 +49,7 @@ export class CommentBlacklist extends RE6Module {
             // Negative filter handling
             // If even one is found, just abort the whole thing. Otherwise, skip
             if (filter.startsWith("-")) {
-                if (comment.includes(filter.substr(1))) return false;
+                if (comment.includes(filter.substring(1))) return false;
                 else matches++;
             } else if (comment.includes(filter)) matches++;
         }

--- a/src/js/modules/general/FormattingExtender.ts
+++ b/src/js/modules/general/FormattingExtender.ts
@@ -131,8 +131,7 @@ export class FormattingExtender extends RE6Module {
     }
 
     public reloadButtonToolbar(): void {
-        const e = document.createEvent('HTMLEvents');
-        e.initEvent("e621:reload", true, true);
+        const e = new Event("e621:reload", { "bubbles": true, "cancelable": true });
         for (const element of $(".dtext-formatter").get())
             element.dispatchEvent(e);
     }

--- a/src/js/modules/general/Miscellaneous.ts
+++ b/src/js/modules/general/Miscellaneous.ts
@@ -307,8 +307,9 @@ export class Miscellaneous extends RE6Module {
 
             $(".re621-forum-post-copy-id").on('click', (event) => {
                 event.preventDefault();
-                const $post = $(event.target).parents("article.forum-post");
-                XM.Util.setClipboard($post.data("forum-post-id"));
+                const id = $(event.target).parents("article.forum-post").data("forum-post-id");
+                XM.Util.setClipboard(id);
+                Danbooru.notice(`Copied forum post ID to clipboard: ${id}`);
             });
         } else if (Page.matches(PageDefinition.post)) {
             $(".content-menu > menu").each(function (index, element) {
@@ -329,8 +330,9 @@ export class Miscellaneous extends RE6Module {
 
             $(".re621-comment-copy-id").on('click', (event) => {
                 event.preventDefault();
-                const $comment = $(event.target).parents("article.comment");
-                XM.Util.setClipboard($comment.data("comment-id"));
+                const id = $(event.target).parents("article.comment").data("comment-id");
+                XM.Util.setClipboard(id);
+                Danbooru.notice(`Copied comment ID to clipboard: ${id}`);
             });
 
             $(".show-all-comments-for-post-link").on("click", async () => {

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -2473,7 +2473,7 @@ export class SettingsController extends RE6Module {
                     poolData = poolSubs.fetchSettings("data");
                 for (const entry of settings) {
                     poolData[entry["id"]] = {
-                        md5: entry["thumb"]["url"].substr(6, 32),
+                        md5: entry["thumb"]["url"].substring(6, 38),
                         lastID: entry["last"],
                     };
                 }

--- a/src/js/modules/misc/SmartAlias.ts
+++ b/src/js/modules/misc/SmartAlias.ts
@@ -869,13 +869,13 @@ namespace ParsedTag {
 
         if (rawTag.startsWith("-")) {
             result.negated = true;
-            rawTag = rawTag.substr(1);
+            rawTag = rawTag.substring(1);
         }
 
         const match = rawTag.match(/(artist|character|copyright|species):/)
         if (match) {
             result.prefix = match[1];
-            rawTag = rawTag.substr(match[0].length);
+            rawTag = rawTag.substring(match[0].length);
         }
 
         result.name = rawTag;

--- a/src/js/modules/subscriptions/CommentTracker.ts
+++ b/src/js/modules/subscriptions/CommentTracker.ts
@@ -227,14 +227,14 @@ export class CommentTracker extends SubscriptionTracker {
 
         function getPreviewLink(md5: string): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
-            return `https://static1.e621.net/data/preview/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`;;
+            return `https://static1.e621.net/data/preview/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`;;
         }
 
         function getSampleLink(md5: string, hasSample: boolean, ext = "jpg"): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
             return hasSample
-                ? `https://static1.e621.net/data/sample/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`
-                : `https://static1.e621.net/data/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.${ext}`;
+                ? `https://static1.e621.net/data/sample/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`
+                : `https://static1.e621.net/data/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.${ext}`;
         }
     }
 

--- a/src/js/modules/subscriptions/PoolTracker.ts
+++ b/src/js/modules/subscriptions/PoolTracker.ts
@@ -233,14 +233,14 @@ export class PoolTracker extends SubscriptionTracker {
 
         function getPreviewLink(md5: string): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
-            return `https://static1.e621.net/data/preview/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`;;
+            return `https://static1.e621.net/data/preview/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`;;
         }
 
         function getSampleLink(md5: string, hasSample: boolean, ext = "jpg"): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
             return hasSample
-                ? `https://static1.e621.net/data/sample/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`
-                : `https://static1.e621.net/data/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.${ext}`;
+                ? `https://static1.e621.net/data/sample/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`
+                : `https://static1.e621.net/data/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.${ext}`;
         }
     }
 

--- a/src/js/modules/subscriptions/TagTracker.ts
+++ b/src/js/modules/subscriptions/TagTracker.ts
@@ -226,14 +226,14 @@ export class TagTracker extends SubscriptionTracker {
 
         function getPreviewLink(md5: string): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
-            return `https://static1.e621.net/data/preview/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`;;
+            return `https://static1.e621.net/data/preview/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`;;
         }
 
         function getSampleLink(md5: string, hasSample: boolean, ext = "jpg"): string {
             if (!md5) return "https://e621.net/images/deleted-preview.png";
             return hasSample
-                ? `https://static1.e621.net/data/sample/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.jpg`
-                : `https://static1.e621.net/data/${md5.substr(0, 2)}/${md5.substr(2, 2)}/${md5}.${ext}`;
+                ? `https://static1.e621.net/data/sample/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.jpg`
+                : `https://static1.e621.net/data/${md5.substring(0, 2)}/${md5.substring(2, 4)}/${md5}.${ext}`;
         }
     }
 


### PR DESCRIPTION
Once again while working on another feature I noticed some deprecated functions in use, and while they probably all work just fine, I thought it might be a good idea to replace them before they become completely obsolete.

**This PR addresses these deprecations:**
- [ ] execCommand
  - [x] In XM.Util.setClipboard
  - [ ] In processFormattingTag (FormattingExtender.ts)
- [x] substr
- [x] initEvent

**Other stuff:**
- [ ] Update browserslist database

It also contains a little adjustment to add a notice when you press "Copy ID" on comments/forum posts.

**Note:** I haven't been able to find a good replacement for execCommand("insertText") as used here https://github.com/bitWolfy/re621/blob/eddef40ac5e607481d6e1e588cf3dcf610fd1a54/src/js/modules/general/FormattingExtender.ts#L188-L192

I'll undraft this once I manage to implement that, or decide to leave it