### PR TITLE
slightly more accurate posts found estimate

### DIFF
--- a/src/js/modules/search/BetterSearch.ts
+++ b/src/js/modules/search/BetterSearch.ts
@@ -245,7 +245,7 @@ export class BetterSearch extends RE6Module {
                                     .attr("title", `${results} posts found`);
                             else
                                 searchStatsCount
-                                    .text("~" + Util.formatK(results) + " Posts")
+                                    .text("~" + Util.formatK(results - math.ceil(postsPerPage * 0.5)) + " Posts")
                                     .attr(
                                         "title",
                                         `Between ${results - postsPerPage} and ${results} posts were found.\nGo to the last page of the search to get the exact number.`


### PR DESCRIPTION
When estimating result count (if not on the last page) based on total page count and `postsPerPage`, since the range is between `results - postsPerPage` and `results`, it's generally a more accurate estimate of the actual result count to find the midpoint of `results - postsPerPage` and `results` instead of just using `results`. This is accomplished by simply subtracting half of `postsPerPage` from `results`.