### PR TITLE
[PoolTracker] Add saving and redirecting to last seen pool post

### DIFF
--- a/src/js/modules/subscriptions/_SubscriptionList.ts
+++ b/src/js/modules/subscriptions/_SubscriptionList.ts
@@ -140,4 +140,6 @@ type ExtraData = {
     name?: string;
     data?: string;
     last?: number;
+    lastSeen?: number;
+    numBehind?: number;
 }


### PR DESCRIPTION
This PR adds functionality to the pool tracker to save the last seen pool post, and inform the user how many posts behind they are and redirects them to their latest seen pool post, instead of just the latest pool post (useful for when you're multiple posts behind)

Currently this redirects the user to their own latest seen pool post, however if you wish I can change this to instead show the latest unseen post. However I feel like currently it is adequate enough without adding too much complexity.

I've been using this branch for almost two weeks now, and I'm pretty sure I've ironed out any bugs, and put in fixes for edge cases. Please tell me if you come across anything else that should be fixed :)

**Also, on a side note:** It was also my intention of adding this type of functionality to the forum tracker as well (using # in the url to highlight new posts), however the API request doesn't give any ID of the latest forum post so there's not much I can do unless I add extra API requests