### PR TITLE
Add thumbnail resize buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ bin/extension-key.pem
 
 # TamperDAV server
 dav/
+
+# Jetbrains IDE
+.idea

--- a/src/js/components/structure/Form.ts
+++ b/src/js/components/structure/Form.ts
@@ -777,7 +777,8 @@ export class Form implements PreparedStructure {
 
         const $element = FormUtils
             .makeInputWrapper(undefined, options.wrapper, options.width)
-            .addClass("checkbox-switch");
+            .addClass("checkbox-switch")
+            .toggleClass("input-disabled", options.disabled == true);
 
         const $input = $("<input>")
             .attr({

--- a/src/js/components/utility/UtilDOM.ts
+++ b/src/js/components/utility/UtilDOM.ts
@@ -5,8 +5,9 @@ export class UtilDOM {
     /**
      * Adds a button to the top-right of the navbar
      * @param config Button configuration
+     * @param target Target element
      */
-    public static addSettingsButton(config: SettingsButton): JQuery<HTMLElement> {
+    public static addSettingsButton(config: SettingsButton, target = "menu.extra"): JQuery<HTMLElement> {
         if (config.name === undefined) config.name = "T";
         if (config.href === undefined) config.href = "";
         if (config.title === undefined) config.title = "";
@@ -16,7 +17,7 @@ export class UtilDOM {
 
         if (config.attr === undefined) config.attr = {};
 
-        const $tab = $(`<li>`).appendTo("menu.extra");
+        const $tab = $(`<li>`).appendTo(target);
         const $link = $("<a>")
             .html(config.name)
             .attr({

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -382,12 +382,20 @@ export class SettingsController extends RE6Module {
                             async (data) => {
                                 await betterSearch.pushSettings("imageSizeChange", data);
                                 if (betterSearch.isInitialized()) betterSearch.updateContentHeader();
-
                                 $("#conf-general-collapse-thumb-scaling-thumbsize-desc").toggleClass("input-disabled", !data);
                                 $("#conf-general-collapse-thumb-scaling-thumbsize")
                                     .prop("disabled", !data)
                                     .parent()
                                     .toggleClass("input-disabled", !data);
+
+                                $("#conf-general-collapse-thumb-scaling-thumbnailResizeButtons")
+                                    .prop("disabled", !data)
+
+                                $("label[for='conf-general-collapse-thumb-scaling-thumbnailResizeButtons']")
+                                    .parent()
+                                    .toggleClass("input-disabled", !data);
+
+                                if (betterSearch.fetchSettings("thumbnailResizeButtons")) BetterSearch.toggleResizeButtons(data)
                             }
                         ),
                         Form.spacer(3, true),
@@ -500,6 +508,20 @@ export class SettingsController extends RE6Module {
                             async (data, input) => {
                                 if (input.val() == "" || !(input.get()[0] as HTMLInputElement).checkValidity()) return;
                                 await betterSearch.pushSettings("imageMinWidth", parseInt(data));
+                                if (betterSearch.isInitialized()) betterSearch.updateContentHeader();
+                            }
+                        ),
+                        Form.spacer(3, true),
+
+                        Form.checkbox(
+                            {
+                                name: "thumbnailResizeButtons",
+                                value: betterSearch.fetchSettings("thumbnailResizeButtons"),
+                                label: '<b>Thumbnail Rescaling Buttons</b><br />Resize the images using the - and + buttons in the top right',
+                                width: 3,
+                            },
+                            async (data) => {
+                                await betterSearch.pushSettings("thumbnailResizeButtons", data);
                                 if (betterSearch.isInitialized()) betterSearch.updateContentHeader();
                             }
                         ),

--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -519,6 +519,7 @@ export class SettingsController extends RE6Module {
                                 value: betterSearch.fetchSettings("thumbnailResizeButtons"),
                                 label: '<b>Thumbnail Rescaling Buttons</b><br />Resize the images using the - and + buttons in the top right',
                                 width: 3,
+                                disabled: !betterSearch.fetchSettings("imageSizeChange"),
                             },
                             async (data) => {
                                 await betterSearch.pushSettings("thumbnailResizeButtons", data);

--- a/src/scss/modules/_header-customizer.scss
+++ b/src/scss/modules/_header-customizer.scss
@@ -65,4 +65,21 @@ header#top nav#nav {
     menu.main.custom:not([data-editing=true]) li[data-right=true] {
         float: right;
     }
+
+    menu:last-child li.float-right {
+        #subnav-button-increase {
+            padding-right: 0.24rem;
+        }
+
+        .resize-disabled {
+            pointer-events: none;
+            cursor: default;
+
+            i {
+                color: #666666;
+            }
+        }
+
+        &[hide-resize-buttons=true] { display: none; }
+    }
 }


### PR DESCRIPTION
Hey, I've been using your extension and it's fantastic so I wanted to contribute. I added thumbnail size buttons so it's easier for users to modify the size of the image thumbnails (similar to artstation). 


![R3P4fxv](https://user-images.githubusercontent.com/109932520/182078230-3897419a-ab73-4f0e-8b6b-eced516c3fbc.gif)


Let me know if there are any problems. I'm a relatively new programmer so I understand if my code doesn't meet the standards.