### PR TITLE
Hide the mobile hamburger button

### DIFF
--- a/src/scss/utilities/_common.scss
+++ b/src/scss/utilities/_common.scss
@@ -9,6 +9,9 @@
     .desktop-only {
         display: none !important;
     }
+    #maintoggle-on {
+        display: none !important;
+    }
 }
 
 a {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/102884856/186176269-ee69df33-733b-4ca0-b01a-0bdb90fee4c7.png)

After
![image](https://user-images.githubusercontent.com/102884856/186176552-c090c733-0eb8-4b84-b5e5-25e0585277a5.png)

Admittedly this is primarily a fix for https://github.com/mandorinn/eSix-Cafe/issues/17 but even without the theme it is still redundant to RE621's menu and doesn't actually work - it should just be hidden.