### PR TITLE
[TagSuggestions] Fix suggestions when more than one implication

### DIFF
--- a/src/js/components/utility/Util.ts
+++ b/src/js/components/utility/Util.ts
@@ -178,7 +178,7 @@ export class Util {
      * @param input Textarea to parse
      */
     public static getTagString(input: JQuery<HTMLElement>): string {
-        const implications = [input.data("implications")] || [];
+        const implications = input.data("implications") || [];
         return input.val().toString().trim()
             .toLowerCase()
             .replace(/\r?\n|\r/g, " ")      // strip newlines


### PR DESCRIPTION
`input.data("implications")` is already an array, resulting in an unnecessarily nested array. Because of this, the implications in the tag string were separated by commas instead of the intended spaces.

Didn't notice this at first because during initial testing I only checked if the suggestions work with tags that have a singular implication.