### PR TITLE
[HoverZoom] Change `isApprover` to `canSeeDeletedPosts`

### DIFF
--- a/src/js/modules/search/HoverZoom.ts
+++ b/src/js/modules/search/HoverZoom.ts
@@ -226,7 +226,7 @@ export class HoverZoom extends RE6Module {
             ) return;
 
             // Skip deleted and flash files
-            if ((post.flags.has(PostFlag.Deleted) && !User.isApprover) || post.file.ext == "swf") return;
+            if ((post.flags.has(PostFlag.Deleted) && !User.canSeeDeletedPosts) || post.file.ext == "swf") return;
 
             const $img = $ref.find("img").first();
             $ref.data("stored-title", $img.attr("title") || "");


### PR DESCRIPTION
This pull request changes HoverZoom's `isApprover` check to `canSeeDeletedPosts`, as more than approvers can see deleted posts.