### PR TITLE
[HeaderCustomizer] Show updates on any forum topics link

### DIFF
--- a/src/js/modules/general/HeaderCustomizer.ts
+++ b/src/js/modules/general/HeaderCustomizer.ts
@@ -287,7 +287,7 @@ export class HeaderCustomizer extends RE6Module {
         if (config.title !== "") $link.attr("title", this.processTabVariables(config.title));
         if (config.href !== "") $link.attr("href", this.processTabVariables(config.href));
 
-        if (config.href === "/forum_topics" && this.hasForumUpdates)
+        if (config.href.startsWith("/forum_topics") && this.hasForumUpdates)
             $link.addClass("tab-has-updates");
         else if ((config.href == "/users/%userid%" || config.href == "/users/home") && !User.loggedIn) {
             $link


### PR DESCRIPTION
I personally have my Forums link set to `/forum_topics?search[order]=created_at`, which breaks the red dot showing up due to the link not being exactly `/forum_topics`.