### PR TITLE
Updated class references related to thumbnail ribbons

### DIFF
--- a/src/js/components/post/Post.ts
+++ b/src/js/components/post/Post.ts
@@ -704,8 +704,8 @@ export namespace PostData {
 
             has: {
                 file: data.fileURL !== undefined,
-                children: $article.hasClass("post-status-has-children"),
-                parent: $article.hasClass("post-status-has-parent"),
+                children: $article.hasClass("has-children"),
+                parent: $article.hasClass("has-parent"),
                 sample: urls["original"] !== urls["sample"],
             },
 

--- a/src/js/modules/search/ThumbnailTweaks.ts
+++ b/src/js/modules/search/ThumbnailTweaks.ts
@@ -23,7 +23,7 @@ export class ThumbnailTweaks extends RE6Module {
 
         const conf = ModuleController.get(BetterSearch).fetchSettings(["ribbonsRel", "ribbonsFlag"]);
         let count = 0;
-        for (const element of $(".post-preview").get()) {
+        for (const element of $(".thumbnail").get()) {
             ThumbnailTweaks.modify($(element), conf.ribbonsRel, conf.ribbonsFlag);
             count++;
         }


### PR DESCRIPTION
Fixes #383

Thanks to [e621 PR #796](https://github.com/e621ng/e621ng/pull/796), the CSS classes used by re621 to pull data were renamed. This commit fixes those class references so ribbons can be rendered outside of search pages. 