### PR TITLE
Janky solution to show blacklist exceptions

### DIFF
--- a/src/js/modules/post/PostViewer.ts
+++ b/src/js/modules/post/PostViewer.ts
@@ -1,5 +1,6 @@
 import { Danbooru } from "../../components/api/Danbooru";
 import { Page, PageDefinition } from "../../components/data/Page";
+import { Blacklist } from "../../components/data/Blacklist";
 import { ModuleController } from "../../components/ModuleController";
 import { Post } from "../../components/post/Post";
 import { PostActions } from "../../components/post/PostActions";
@@ -133,6 +134,11 @@ export class PostViewer extends RE6Module {
         if (!Page.matches(PageDefinition.post)) return;
 
         this.post = Post.getViewingPost()
+        
+        if (Blacklist.addPost(this.post) == 0) { //no filters match, allows for BlacklistEnhancer exceptions
+            $("#image-container").removeClass("blacklisted");
+        }
+
 
         // Move the add to set / pool buttons
         const $addToContainer = $("<div>").attr("id", "image-add-links").insertAfter("div#image-download-link");


### PR DESCRIPTION
If a blacklisted post has an exception (whitelist, favorite, or user upload), this solution shows the post on initial load on the post page. It does not recognize that the post isn't "blacklisted" because of the exception, and disabling/re-enabling the active filter re-hides the post.

Ideally, this would use the `BlacklistEnhancer` module so that the blacklist UI in the sidebar could be handled, as well as any parent/child posts that also have exceptions. However, that would require overhauling the module to allow it to also be present on Post pages, which would in turn require a similar overhaul for the `BetterSearch` module since the two are dependent on each other. This works as an ugly stopgap in the meantime, but any guidance for making it more robust would be appreciated.

Resolves #390