### PR TITLE
Adds a color option to "Underline Visited Posts"

### DIFF
--- a/src/js/modules/general/SettingsController.ts
+++ b/src/js/modules/general/SettingsController.ts
@@ -624,14 +624,29 @@ export class SettingsController extends RE6Module {
           Form.checkbox(
             {
               value: betterSearch.fetchSettings("highlightVisited"),
-              label: "<b>Underline Visited Posts</b><br />Adds an orange bottom border to visited posts",
-              width: 3,
+              label: "<b>Underline Visited Posts</b><br />Adds an colored bottom border to visited posts",
+              width: 2,
             },
             async (data) => {
               await betterSearch.pushSettings("highlightVisited", data);
               if (betterSearch.isInitialized()) betterSearch.updateContentHeader();
             },
           ),
+          Form.div({
+            value: $("<input>")
+              .attr({
+                "type": "color",
+                "placeholder": "color",
+              })
+              .val(betterSearch.fetchSettings("highlightVisitedColor"))
+              .on("input", async (event) => {
+                const $target = $(event.target);
+                if (($target.val() + "").match(/^#(?:[0-9a-f]{3}){1,2}$/i)) {
+                  await betterSearch.pushSettings("highlightVisitedColor", $target.val());
+                  if (betterSearch.isInitialized()) betterSearch.updateContentHeader();
+                }
+              }),
+          }),
           Form.spacer(3, true),
 
           Form.checkbox(

--- a/src/js/modules/search/BetterSearch.ts
+++ b/src/js/modules/search/BetterSearch.ts
@@ -85,6 +85,7 @@ export class BetterSearch extends RE6Module {
       hidePageBreaks: true,                           // Show a visual separator between different pages
 
       highlightVisited: true,                         // Adds a colored border to visited posts
+      highlightVisitedColor: "#d2a109",               // The border color for visited posts
       hideSmartAliasOutput: false,                    // Run SmartAlias, but don't show its output, in the quick edit mode
 
       hideInfoBar: false,                             // Remove the post info (votes, favorites, etc) from view
@@ -605,6 +606,7 @@ export class BetterSearch extends RE6Module {
 
       "hidePageBreaks",
       "highlightVisited",
+      "highlightVisitedColor",
       "hideSmartAliasOutput",
 
       "hideInfoBar",
@@ -618,6 +620,7 @@ export class BetterSearch extends RE6Module {
     if (conf.imageRatioChange) this.$content.css("--img-ratio", conf.imageRatio);
     else this.$content.css("--img-fit", Util.Math.clamp(conf.imageMinWidth, 10, 100) + "%");
     if (conf.compactMode) this.$content.css("--img-maxheight", (conf.imageSizeChange ? conf.imageWidth : 150) + "px");
+    if (conf.highlightVisited) this.$content.css("--highlight-visited-color", conf.highlightVisitedColor);
 
     // Hide the SmartAlias output in the quick edit form
     if (conf.hideSmartAliasOutput) $("#content").attr("hide-smart-alias-output", "true");

--- a/src/scss/modules/_better-search.scss
+++ b/src/scss/modules/_better-search.scss
@@ -356,7 +356,7 @@ search-content > post[deleted=true] > a:after { content: "DELETED" }
 
 /* Visited Highlights */
 search-content[highlight-visited=true] > post > a { border-bottom: 0.05rem solid #444; }
-search-content[highlight-visited=true] > post > a:visited { border-bottom-color: #d2a109; }
+search-content[highlight-visited=true] > post > a:visited { border-bottom-color: var(--highlight-visited-color, #d2a109); }
 search-content[highlight-visited=true] > post[rendered=false] {
     border-bottom: 1.05rem solid #ffffff25;
 }


### PR DESCRIPTION
Adds a color option to "Underline Visited Posts"
There was no color input form, and i didn't have the pain of going through and testing a bunch of edge cases so it ends up being a div with a manually set input inside it.
This allows users to change the color setting for "Underline Visited Posts" to help with visibility. I really liked this feature, but I usually couldn't tell if I had clicked on something because of poor contrast.

Feature Video:

https://github.com/user-attachments/assets/ec55c19c-522a-4ef3-8685-6e4d779434d9

